### PR TITLE
fix: prepo-react-boilerplate rename title on readme

### DIFF
--- a/apps/prepo-react-boilerplate/README.md
+++ b/apps/prepo-react-boilerplate/README.md
@@ -1,4 +1,4 @@
-# prePO React Boilerplate
+# prepo-react-boilerplate
 
 ## What is this?
 


### PR DESCRIPTION
## Description
This PR should trigger a build on vercel **only** for prepo-react-boilerplate