### PR TITLE
feat: acquisition royale enterprises carousel

### DIFF
--- a/apps/frontend/acquisition-royale-home/src/components/EnterpriseCard.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/EnterpriseCard.tsx
@@ -1,22 +1,15 @@
 import { Card, CardProps } from 'antd'
-import { observer } from 'mobx-react-lite'
 import styled, { DefaultTheme, FlattenInterpolation, ThemeProps } from 'styled-components'
 import LoadingCarouselCard from './LoadingCarouselCard'
 import { formatPeriod } from '../utils/date-utils'
 import { Z_INDEX } from '../utils/theme/general-settings'
-import {
-  centered,
-  primaryBoxShadowGlow,
-  redBoxShadowGlow,
-  spacingIncrement,
-} from '../utils/theme/utils'
+import { centered, primaryBoxShadowGlow, spacingIncrement } from '../utils/theme/utils'
 import { Enterprise } from '../types/enterprise.types'
 
 type Props = {
   active?: boolean
   enterprise?: Enterprise
   isCompetitor?: boolean
-  onClick?: (id: number) => void
 }
 
 const Burnt = styled.p`
@@ -65,31 +58,15 @@ const TextWrapper = styled.div<{ active?: boolean }>`
   text-align: center;
 `
 
-const Wrapper = styled.div<{
-  active?: boolean
-  burned?: boolean
-  isCompetitor?: boolean
-}>`
-  padding: ${spacingIncrement(16)} 0;
+const Wrapper = styled.div<{ active?: boolean; burned?: boolean }>`
   ${({ burned }): string => (burned ? 'cursor: not-allowed;' : '')}
   &&& {
     .ant-card {
       background-color: transparent;
       margin: 0 ${spacingIncrement(14)};
       .ant-card-cover {
-        ${({
-          active,
-          isCompetitor,
-        }): FlattenInterpolation<ThemeProps<DefaultTheme>> | undefined => {
-          if (active) {
-            if (isCompetitor) {
-              return redBoxShadowGlow
-            }
-            return primaryBoxShadowGlow
-          }
-
-          return undefined
-        }};
+        ${({ active }): FlattenInterpolation<ThemeProps<DefaultTheme>> | undefined =>
+          active ? primaryBoxShadowGlow : undefined};
         background-color: ${({ theme }): string => theme.color.primary};
         border: 1px solid ${({ theme }): string => theme.color.accentPrimary};
         cursor: pointer;
@@ -111,12 +88,7 @@ const StyledImage = styled.img`
   object-fit: cover;
 `
 
-const EnterpriseCard: React.FC<Props> = ({
-  active = false,
-  enterprise,
-  isCompetitor = false,
-  onClick,
-}) => {
+const EnterpriseCard: React.FC<Props> = ({ active = false, enterprise }) => {
   if (
     !enterprise ||
     !enterprise.art ||
@@ -129,13 +101,7 @@ const EnterpriseCard: React.FC<Props> = ({
   const { burned, id, art, immune, immuneUntil } = enterprise
 
   return (
-    <Wrapper
-      active={active}
-      burned={burned}
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      onClick={onClick && !burned ? (): void => onClick(id) : (): void => {}}
-      isCompetitor={isCompetitor}
-    >
+    <Wrapper active={active} burned={burned}>
       <StyledCard bordered={false} cover={<StyledImage alt={id.toString()} src={art.image} />}>
         <TextWrapper active={active} />
         {burned && (
@@ -163,4 +129,4 @@ export type EnterpriseCardProps = Props
 
 export type EnterpriseProps = Omit<EnterpriseCardProps, 'isCompetitor'>
 
-export default observer(EnterpriseCard)
+export default EnterpriseCard

--- a/apps/frontend/acquisition-royale-home/src/components/EnterpriseCard.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/EnterpriseCard.tsx
@@ -1,9 +1,9 @@
 import { Card, CardProps } from 'antd'
-import styled, { DefaultTheme, FlattenInterpolation, ThemeProps } from 'styled-components'
+import styled from 'styled-components'
 import LoadingCarouselCard from './LoadingCarouselCard'
 import { formatPeriod } from '../utils/date-utils'
 import { Z_INDEX } from '../utils/theme/general-settings'
-import { centered, primaryBoxShadowGlow, spacingIncrement } from '../utils/theme/utils'
+import { centered, spacingIncrement } from '../utils/theme/utils'
 import { Enterprise } from '../types/enterprise.types'
 
 type Props = {
@@ -58,15 +58,13 @@ const TextWrapper = styled.div<{ active?: boolean }>`
   text-align: center;
 `
 
-const Wrapper = styled.div<{ active?: boolean; burned?: boolean }>`
-  ${({ burned }): string => (burned ? 'cursor: not-allowed;' : '')}
+const Wrapper = styled.div<{ $burned?: boolean }>`
+  ${({ $burned }): string => ($burned ? 'cursor: not-allowed;' : '')}
   &&& {
     .ant-card {
       background-color: transparent;
-      margin: 0 ${spacingIncrement(14)};
+      margin: 0;
       .ant-card-cover {
-        ${({ active }): FlattenInterpolation<ThemeProps<DefaultTheme>> | undefined =>
-          active ? primaryBoxShadowGlow : undefined};
         background-color: ${({ theme }): string => theme.color.primary};
         border: 1px solid ${({ theme }): string => theme.color.accentPrimary};
         cursor: pointer;
@@ -101,7 +99,7 @@ const EnterpriseCard: React.FC<Props> = ({ active = false, enterprise }) => {
   const { burned, id, art, immune, immuneUntil } = enterprise
 
   return (
-    <Wrapper active={active} burned={burned}>
+    <Wrapper $burned={burned}>
       <StyledCard bordered={false} cover={<StyledImage alt={id.toString()} src={art.image} />}>
         <TextWrapper active={active} />
         {burned && (

--- a/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
@@ -206,7 +206,7 @@ const EnterpriseCarousel: React.FC<Props> = ({
           <ArrowComponent direction="right" onClick={(): void => swiperRef?.slideNext()} />
         )}
       </InnerWrapper>
-      {enterprises && enterprises.length > 0 && activeIndex !== undefined && (
+      {enterprises && enterprises.length > 1 && activeIndex !== undefined && (
         <Labels>
           {activeIndex + 1}/{enterprises.length}
         </Labels>

--- a/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
@@ -169,7 +169,7 @@ const EnterpriseCarousel: React.FC<Props> = ({
         <SwiperComponent
           onActiveIndexChange={(swiper): void => {
             onActiveSlidesChange?.({
-              enterpriseId: enterprises?.[swiper.activeIndex].id,
+              enterpriseId: enterprises?.[swiper.activeIndex]?.id,
               slides: swiper.activeIndex + SLIDES_PER_VIEW,
             })
           }}

--- a/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
@@ -163,29 +163,6 @@ const EnterpriseCarousel: React.FC<Props> = ({
     ))
   }, [activeIndex, enterprises, placeholderEnterprises])
 
-  const renderContent = useMemo(
-    () => (
-      <SwiperWrapper>
-        <SwiperComponent
-          onActiveIndexChange={(swiper): void => {
-            onActiveSlidesChange?.({
-              enterpriseId: enterprises?.[swiper.activeIndex]?.id,
-              slides: swiper.activeIndex + SLIDES_PER_VIEW,
-            })
-          }}
-          spaceBetween={20}
-          slidesPerView={SLIDES_PER_VIEW}
-          onSwiper={setSwiperRef}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...swiperProps}
-        >
-          {renderCards}
-        </SwiperComponent>
-      </SwiperWrapper>
-    ),
-    [enterprises, onActiveSlidesChange, renderCards, swiperProps]
-  )
-
   return (
     <Wrapper>
       {overlay && (
@@ -201,7 +178,23 @@ const EnterpriseCarousel: React.FC<Props> = ({
         {showArrow && (
           <ArrowComponent direction="left" onClick={(): void => swiperRef?.slidePrev()} />
         )}
-        {renderContent}
+        <SwiperWrapper>
+          <SwiperComponent
+            onActiveIndexChange={(swiper): void => {
+              onActiveSlidesChange?.({
+                enterpriseId: enterprises?.[swiper.activeIndex]?.id,
+                slides: swiper.activeIndex + SLIDES_PER_VIEW,
+              })
+            }}
+            spaceBetween={20}
+            slidesPerView={SLIDES_PER_VIEW}
+            onSwiper={setSwiperRef}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...swiperProps}
+          >
+            {renderCards}
+          </SwiperComponent>
+        </SwiperWrapper>
         {showArrow && (
           <ArrowComponent direction="right" onClick={(): void => swiperRef?.slideNext()} />
         )}

--- a/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
@@ -158,7 +158,7 @@ const EnterpriseCarousel: React.FC<Props> = ({
 
     return placeholderEnterprises.map((id) => (
       <SwiperSlideComponent key={id} style={SwiperStyle}>
-        <LoadingCarouselCard key={id} loading />
+        <LoadingCarouselCard key={id} loading={enterprises === undefined} />
       </SwiperSlideComponent>
     ))
   }, [activeIndex, enterprises, placeholderEnterprises])
@@ -206,7 +206,7 @@ const EnterpriseCarousel: React.FC<Props> = ({
           <ArrowComponent direction="right" onClick={(): void => swiperRef?.slideNext()} />
         )}
       </InnerWrapper>
-      {enterprises && (
+      {enterprises && enterprises.length > 0 && activeIndex !== undefined && (
         <Labels>
           {activeIndex + 1}/{enterprises.length}
         </Labels>

--- a/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/EnterpriseCarousel.tsx
@@ -28,12 +28,14 @@ export type OverlayProps = {
   action?: React.ReactNode
   message?: React.ReactNode
 }
+
 type Props = {
   activeIndex?: number
   enterprises?: { id: number; component: React.ReactNode }[]
   loading?: boolean
   overlay?: OverlayProps
   onActiveSlidesChange?: (props: { enterpriseId?: number; slides: number }) => unknown
+  title?: string
 } & SwiperProps
 
 const ArrowWrapper = styled.div<Omit<ArrowProps, 'onClick'>>`
@@ -42,9 +44,11 @@ const ArrowWrapper = styled.div<Omit<ArrowProps, 'onClick'>>`
   border-radius: ${({ direction }): string =>
     direction === 'left' ? '12px 6px 6px 12px' : '6px 12px 12px 6px'};
   cursor: pointer;
-  top: ${spacingIncrement(16)};
-  width: ${spacingIncrement(39)};
-  z-index: 5;
+  height: 100%;
+  position: absolute;
+  ${({ direction }): string => (direction === 'left' ? 'left: 0' : 'right: 0')};
+  width: 8%;
+  z-index: 1;
 `
 
 const ArrowIconWrapper = styled(Icon)`
@@ -55,8 +59,8 @@ const ArrowIconWrapper = styled(Icon)`
 const InnerWrapper = styled.div`
   align-items: stretch;
   display: flex;
+  gap: ${spacingIncrement(14)};
   justify-content: center;
-  max-width: ${spacingIncrement(1200)};
   position: relative;
   width: 100%;
 `
@@ -85,16 +89,24 @@ const OverlayActionWrapper = styled.div`
   width: 100%;
 `
 
+const Labels = styled.p`
+  color: ${({ theme }): string => theme.color.white};
+  font-size: ${({ theme }): string => theme.fontSize.base};
+  font-weight: ${({ theme }): number => theme.fontWeight.bold};
+  margin-bottom: 0;
+  text-align: center;
+`
+
 const SwiperWrapper = styled.div`
   display: flex;
-  flex: 1;
-  max-width: ${spacingIncrement(400)};
+  padding: 0 12%;
   width: 100%;
 `
 
 const Wrapper = styled.div`
   ${centered}
   flex-direction: column;
+  gap: ${spacingIncrement(12)};
   position: relative;
   width: 100%;
 `
@@ -113,6 +125,7 @@ const EnterpriseCarousel: React.FC<Props> = ({
   loading,
   onActiveSlidesChange,
   overlay,
+  title,
   ...swiperProps
 }) => {
   const [swiperRef, setSwiperRef] = useState<SwiperCore>()
@@ -167,6 +180,7 @@ const EnterpriseCarousel: React.FC<Props> = ({
           )}
         </MessageOverlay>
       )}
+      {Boolean(title) && <Labels>{title}</Labels>}
       <InnerWrapper>
         {showArrow && (
           <ArrowComponent direction="left" onClick={(): void => swiperRef?.slidePrev()} />
@@ -176,6 +190,11 @@ const EnterpriseCarousel: React.FC<Props> = ({
           <ArrowComponent direction="right" onClick={(): void => swiperRef?.slideNext()} />
         )}
       </InnerWrapper>
+      {enterprises && (
+        <Labels>
+          {activeIndex + 1}/{enterprises.length}
+        </Labels>
+      )}
     </Wrapper>
   )
 }

--- a/apps/frontend/acquisition-royale-home/src/components/LoadingCarouselCard.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/LoadingCarouselCard.tsx
@@ -9,6 +9,7 @@ type Props = {
 const StyledImage = styled.img`
   height: auto;
   object-fit: cover;
+  opacity: 0.8;
 `
 
 const skeletonAnimation = keyframes`
@@ -28,12 +29,12 @@ const Wrapper = styled.div<{ shouldAnimate: boolean }>`
   opacity: 0.6;
   &&& {
     .ant-card {
-      background: transparent;
       border: none;
       flex-direction: column;
-      margin: ${spacingIncrement(16)} ${spacingIncrement(14)};
+      margin: 0 ${spacingIncrement(14)};
     }
     .ant-card-body {
+      background-color: ${({ theme }): string => theme.color.accentPrimary};
       padding: 0;
     }
   }

--- a/apps/frontend/acquisition-royale-home/src/components/MainTab.tsx
+++ b/apps/frontend/acquisition-royale-home/src/components/MainTab.tsx
@@ -86,11 +86,11 @@ const MainTab: React.FC<TabsProps & { subtabs?: string[] }> = ({
   const [activeKey, setActiveKey] = useState(defaultActiveKey)
   return (
     <Wrapper $showSubtabArrow={subtabs.includes(activeKey)}>
-      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <Tabs
         defaultActiveKey={defaultActiveKey}
         onChange={setActiveKey}
         animated={{ inkBar: false }}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       />
     </Wrapper>

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/ActionCard.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/ActionCard.tsx
@@ -165,6 +165,7 @@ const ActionCard: React.FC<Props> = ({
   balances,
   balanceLabel = 'Balance',
   buttonProps,
+  children,
   comparisons,
   comingSoon,
   costs,
@@ -271,6 +272,7 @@ const ActionCard: React.FC<Props> = ({
     <Wrapper onSubmit={handleSubmit}>
       <FancyTitle>{title}</FancyTitle>
       <Description>{description}</Description>
+      {children}
       {Boolean(input) && <InputWrapper>{input}</InputWrapper>}
       {(cost !== null || balance !== null) && (
         <SummaryWrapper>

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/ActionCard.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/ActionCard.tsx
@@ -146,7 +146,7 @@ const SummaryWrapper = styled.div`
   padding: ${spacingIncrement(8)} ${spacingIncrement(4)};
 `
 
-const Wrapper = styled.form`
+const Wrapper = styled.div`
   background-color: ${({ theme }): string => theme.color.secondary};
   border: solid 1px ${({ theme }): string => theme.color.accentPrimary};
   box-shadow: 0px 2px 24px ${({ theme }): string => theme.color.accentPrimary};
@@ -269,24 +269,26 @@ const ActionCard: React.FC<Props> = ({
   }
 
   return (
-    <Wrapper onSubmit={handleSubmit}>
+    <Wrapper>
       <FancyTitle>{title}</FancyTitle>
       <Description>{description}</Description>
       {children}
-      {Boolean(input) && <InputWrapper>{input}</InputWrapper>}
-      {(cost !== null || balance !== null) && (
-        <SummaryWrapper>
-          {cost}
-          {balance}
-        </SummaryWrapper>
-      )}
-      {lowMatic && (
-        <LowMaticWrapper>
-          <LowMatic />
-        </LowMaticWrapper>
-      )}
-      <Center>{reward}</Center>
-      <ActionWrapper>{button}</ActionWrapper>
+      <form onSubmit={handleSubmit}>
+        {Boolean(input) && <InputWrapper>{input}</InputWrapper>}
+        {(cost !== null || balance !== null) && (
+          <SummaryWrapper>
+            {cost}
+            {balance}
+          </SummaryWrapper>
+        )}
+        {lowMatic && (
+          <LowMaticWrapper>
+            <LowMatic />
+          </LowMaticWrapper>
+        )}
+        <Center>{reward}</Center>
+        <ActionWrapper>{button}</ActionWrapper>
+      </form>
       {messageBelowButton}
       {comparisons &&
         comparisons.map((comparison) => (

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/ActionsStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/ActionsStore.ts
@@ -32,8 +32,8 @@ export class ActionsStore {
   // action props ...
 
   get competeButtonProps(): ButtonProps {
-    const { competitionActiveEnterprise, signerActiveEnterprise, signerEnterprises } =
-      this.root.enterprisesStore
+    const { signerActiveEnterprise, signerEnterprises } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     const { competeRp } = this.root.acquisitionRoyaleContractStore
 
     if (signerEnterprises && signerEnterprises.length === 0) {
@@ -64,7 +64,7 @@ export class ActionsStore {
 
   get depositButtonProps(): ButtonProps {
     const { balance } = this.root.runwayPointsContractStore
-    const { signerEnterprises, signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerEnterprises, signerActiveEnterprise } = this.root.signerStore
     const { depositAmount } = this.root.acquisitionRoyaleContractStore
     if (signerEnterprises && signerEnterprises.length === 0) {
       return { disabled: true, children: 'No owned Enterprise' }
@@ -137,7 +137,7 @@ export class ActionsStore {
   }
 
   get rebrandButtonProps(): ButtonProps {
-    const { signerActiveEnterprise, signerEnterprises } = this.root.enterprisesStore
+    const { signerActiveEnterprise, signerEnterprises } = this.root.signerStore
     const { rebrandAddress } = this.root.acquisitionRoyaleContractStore
     const { rebrandBalance } = this.root.consumablesContractStore
     if (signerEnterprises && signerEnterprises.length === 0) {
@@ -160,7 +160,7 @@ export class ActionsStore {
   }
 
   get renameButtonProps(): ButtonProps {
-    const { signerActiveEnterprise, signerEnterprises } = this.root.enterprisesStore
+    const { signerActiveEnterprise, signerEnterprises } = this.root.signerStore
     const { newName } = this.root.acquisitionRoyaleContractStore
     const { renameBalance } = this.root.consumablesContractStore
     if (signerEnterprises && signerEnterprises.length === 0) {
@@ -181,7 +181,7 @@ export class ActionsStore {
   }
 
   get reviveButtonProps(): ButtonProps {
-    const { competitionActiveEnterprise } = this.root.enterprisesStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     const { reviveBalance } = this.root.consumablesContractStore
     if (reviveBalance === undefined) {
       return LOADING
@@ -200,7 +200,7 @@ export class ActionsStore {
 
   get withdrawButtonProps(): ButtonProps {
     const { balance } = this.root.runwayPointsContractStore
-    const { signerActiveEnterprise, signerEnterprises } = this.root.enterprisesStore
+    const { signerActiveEnterprise, signerEnterprises } = this.root.signerStore
     const { withdrawAmount } = this.root.acquisitionRoyaleContractStore
     if (signerEnterprises && signerEnterprises.length === 0) {
       return { disabled: true, children: 'No owned Enterprise' }
@@ -222,7 +222,7 @@ export class ActionsStore {
   // balances ...
 
   get competeBalances(): CostBalance[] {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     return [makeRPCostBalance(signerActiveEnterprise?.stats.rp || 0)]
   }
 
@@ -250,7 +250,7 @@ export class ActionsStore {
   }
 
   get withdrawBalances(): CostBalance[] {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     return [makeRPCostBalance(signerActiveEnterprise?.stats.rp || 0)]
   }
 
@@ -282,7 +282,8 @@ export class ActionsStore {
   // stats comparisons ...
 
   get competeComparisons(): ComparisonProps[] | undefined {
-    const { signerActiveEnterprise, competitionActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     const { competeRp } = this.root.acquisitionRoyaleContractStore
     const { damage } = this.root.competeV1ContractStore
     if (!signerActiveEnterprise || !competitionActiveEnterprise || damage === undefined)
@@ -318,7 +319,7 @@ export class ActionsStore {
   }
 
   get depositComparisons(): ComparisonProps[] | undefined {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     const { depositAmount } = this.root.acquisitionRoyaleContractStore
     if (!signerActiveEnterprise || depositAmount === '') return undefined
     const formattedRpBefore = formatNumberToNumber(signerActiveEnterprise.stats.rp)
@@ -377,7 +378,7 @@ export class ActionsStore {
 
   get withdrawComparisons(): ComparisonProps[] | undefined {
     const { balance } = this.root.runwayPointsContractStore
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     const { withdrawAmount, withdrawalBurnPercentage } = this.root.acquisitionRoyaleContractStore
     if (
       !signerActiveEnterprise ||

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
@@ -5,13 +5,16 @@ import EnterpriseCarousel, { OverlayProps } from '../../components/EnterpriseCar
 import { useRootStore } from '../../context/RootStoreProvider'
 import { spacingIncrement } from '../../utils/theme/utils'
 
+type Props = {
+  label?: string
+}
 const Wrapper = styled.div`
   margin-bottom: ${spacingIncrement(44)};
   position: relative;
   width: 100%;
 `
 
-const Competition: React.FC = () => {
+const Competition: React.FC<Props> = ({ label }) => {
   const { competitionStore } = useRootStore()
   const { activeIndex, competitionEnterprises, searchCompetitionQuery, onSlidesChange } =
     competitionStore
@@ -37,7 +40,7 @@ const Competition: React.FC = () => {
 
   return (
     <Wrapper>
-      <SearchCompetition />
+      <SearchCompetition label={label} />
       <EnterpriseCarousel
         activeIndex={activeIndex}
         enterprises={competitionEnterprises}

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
@@ -1,12 +1,9 @@
 import { observer } from 'mobx-react-lite'
 import styled from 'styled-components'
-import EnterpriseCard from '../../components/EnterpriseCard'
+import SearchCompetition from './SearchCompetition'
 import EnterpriseCarousel, { OverlayProps } from '../../components/EnterpriseCarousel'
 import { useRootStore } from '../../context/RootStoreProvider'
-import { centered, spacingIncrement } from '../../utils/theme/utils'
-import { isEnterpriseLoaded, isFirstEnterpriseLoaded } from '../../utils/enterprise-utils'
-import LoadingCarouselCard from '../../components/LoadingCarouselCard'
-import { Enterprise } from '../../types/enterprise.types'
+import { spacingIncrement } from '../../utils/theme/utils'
 
 const Wrapper = styled.div`
   margin-bottom: ${spacingIncrement(44)};
@@ -14,17 +11,10 @@ const Wrapper = styled.div`
   width: 100%;
 `
 
-const SearchByIdWrapper = styled.div`
-  ${centered}
-  width: 100%;
-`
-
 const Competition: React.FC = () => {
   const { competitionStore } = useRootStore()
-  const { competitionEnterprises, searchCompetitionQuery, activeEnterpriseId, onSlidesChange } =
+  const { activeIndex, competitionEnterprises, searchCompetitionQuery, onSlidesChange } =
     competitionStore
-
-  const doneLoading = (): boolean => isFirstEnterpriseLoaded(competitionEnterprises)
 
   const overlay = (): OverlayProps | undefined => {
     // if searchCompetitionQuery is empty, user hasn't searched anything
@@ -45,41 +35,16 @@ const Competition: React.FC = () => {
     return undefined
   }
 
-  const showEnterpriseCard = (enterprise: Enterprise | undefined): React.ReactNode =>
-    enterprise && isEnterpriseLoaded(enterprise) ? (
-      <EnterpriseCard
-        active={enterprise !== undefined && enterprise.id === activeEnterpriseId}
-        enterprise={enterprise}
-        isCompetitor
-      />
-    ) : (
-      <LoadingCarouselCard />
-    )
-
   return (
     <Wrapper>
-      {competitionEnterprises !== undefined &&
-      doneLoading() &&
-      competitionEnterprises.length === 0 &&
-      competitionEnterprises[0] ? (
-        <SearchByIdWrapper>
-          <EnterpriseCard active enterprise={competitionEnterprises[0]} isCompetitor />
-        </SearchByIdWrapper>
-      ) : (
-        <EnterpriseCarousel
-          enterprises={
-            doneLoading()
-              ? competitionEnterprises?.map((enterprise) => ({
-                  id: enterprise.id,
-                  component: showEnterpriseCard(enterprise),
-                }))
-              : undefined
-          }
-          loading={Boolean(searchCompetitionQuery) && competitionEnterprises === undefined}
-          onActiveSlidesChange={onSlidesChange}
-          overlay={overlay()}
-        />
-      )}
+      <SearchCompetition />
+      <EnterpriseCarousel
+        activeIndex={activeIndex}
+        enterprises={competitionEnterprises}
+        loading={Boolean(searchCompetitionQuery) && competitionEnterprises === undefined}
+        onActiveSlidesChange={onSlidesChange}
+        overlay={overlay()}
+      />
     </Wrapper>
   )
 }

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
@@ -20,13 +20,9 @@ const SearchByIdWrapper = styled.div`
 `
 
 const Competition: React.FC = () => {
-  const { enterprisesStore } = useRootStore()
-  const {
-    competitionEnterprises,
-    searchCompetitionQuery,
-    competitionActiveEnterpriseId,
-    setCompetitionSlides,
-  } = enterprisesStore
+  const { competitionStore } = useRootStore()
+  const { competitionEnterprises, searchCompetitionQuery, activeEnterpriseId, onSlidesChange } =
+    competitionStore
 
   const doneLoading = (): boolean => isFirstEnterpriseLoaded(competitionEnterprises)
 
@@ -52,9 +48,8 @@ const Competition: React.FC = () => {
   const showEnterpriseCard = (enterprise: Enterprise | undefined): React.ReactNode =>
     enterprise && isEnterpriseLoaded(enterprise) ? (
       <EnterpriseCard
-        active={enterprise !== undefined && enterprise.id === competitionActiveEnterpriseId}
+        active={enterprise !== undefined && enterprise.id === activeEnterpriseId}
         enterprise={enterprise}
-        onClick={enterprisesStore.setCompetitionEnterpriseActiveId}
         isCompetitor
       />
     ) : (
@@ -68,12 +63,7 @@ const Competition: React.FC = () => {
       competitionEnterprises.length === 0 &&
       competitionEnterprises[0] ? (
         <SearchByIdWrapper>
-          <EnterpriseCard
-            active
-            enterprise={competitionEnterprises[0]}
-            isCompetitor
-            onClick={enterprisesStore.setCompetitionEnterpriseActiveId}
-          />
+          <EnterpriseCard active enterprise={competitionEnterprises[0]} isCompetitor />
         </SearchByIdWrapper>
       ) : (
         <EnterpriseCarousel
@@ -86,7 +76,7 @@ const Competition: React.FC = () => {
               : undefined
           }
           loading={Boolean(searchCompetitionQuery) && competitionEnterprises === undefined}
-          onActiveSlidesChange={setCompetitionSlides}
+          onActiveSlidesChange={onSlidesChange}
           overlay={overlay()}
         />
       )}

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/Competition.tsx
@@ -9,7 +9,7 @@ type Props = {
   label?: string
 }
 const Wrapper = styled.div`
-  margin-bottom: ${spacingIncrement(44)};
+  margin-top: ${spacingIncrement(44)};
   position: relative;
   width: 100%;
 `

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/GamePage.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/GamePage.tsx
@@ -1,13 +1,10 @@
 import styled from 'styled-components'
-import { observer } from 'mobx-react-lite'
 import categories from './categories'
-import MyEnterprises from './MyEnterprises'
 import RemainingEnterprises from './RemainingEnterprises'
 import Section from '../../components/Section'
 import { spacingIncrement } from '../../utils/theme/utils'
 import MainTab, { TabPane } from '../../components/MainTab'
 import { media } from '../../utils/theme/media'
-import { useRootStore } from '../../context/RootStoreProvider'
 import Subtabs from '../../components/Subtabs'
 
 const CenterWrapper = styled.div`
@@ -26,9 +23,6 @@ const Wrapper = styled.div`
 `
 
 const GamePage: React.FC = () => {
-  const { enterprisesStore } = useRootStore()
-  const { enterprisesBalance } = enterprisesStore
-
   const subtabsList = categories
     .filter(({ subtabs }) => subtabs !== undefined)
     .map(({ tab }) => tab)
@@ -37,9 +31,6 @@ const GamePage: React.FC = () => {
     <Wrapper>
       <Section>
         <RemainingEnterprises />
-      </Section>
-      <Section greyOnUnconnected title={`Your Enterprises (${enterprisesBalance ?? '...'})`}>
-        <MyEnterprises />
       </Section>
       <MainTab subtabs={subtabsList} defaultActiveKey={subtabsList[0]} centered>
         {categories.map(({ tab, content, subtabs }) => (
@@ -53,4 +44,4 @@ const GamePage: React.FC = () => {
   )
 }
 
-export default observer(GamePage)
+export default GamePage

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
@@ -1,14 +1,10 @@
 import { observer } from 'mobx-react-lite'
 import styled from 'styled-components'
 import Button from '../../components/Button'
-import EnterpriseCard from '../../components/EnterpriseCard'
 import EnterpriseCarousel, { OverlayProps } from '../../components/EnterpriseCarousel'
 import { useRootStore } from '../../context/RootStoreProvider'
 import { spacingIncrement } from '../../utils/theme/utils'
 import ConnectButton from '../connect/ConnectButton'
-import { isEnterpriseLoaded, isFirstEnterpriseLoaded } from '../../utils/enterprise-utils'
-import { Enterprise } from '../../types/enterprise.types'
-import LoadingCarouselCard from '../../components/LoadingCarouselCard'
 
 const Wrapper = styled.div`
   margin: ${spacingIncrement(44)} 0;
@@ -18,10 +14,7 @@ const Wrapper = styled.div`
 const MyEnterprises: React.FC = () => {
   const { signerStore, web3Store } = useRootStore()
   const { connected } = web3Store
-  const { activeIndex, onSignerSlidesChange, signerEnterprises, signerActiveEnterprise } =
-    signerStore
-
-  const doneLoading = (): boolean => isFirstEnterpriseLoaded(signerEnterprises)
+  const { activeIndex, onSignerSlidesChange, signerEnterprises } = signerStore
 
   const overlay = (): OverlayProps | undefined => {
     if (!connected)
@@ -41,28 +34,11 @@ const MyEnterprises: React.FC = () => {
     return undefined
   }
 
-  const showEnterpriseCard = (enterprise: Enterprise | undefined): React.ReactNode =>
-    enterprise && isEnterpriseLoaded(enterprise) ? (
-      <EnterpriseCard
-        enterprise={enterprise}
-        active={signerActiveEnterprise && enterprise?.id === signerActiveEnterprise?.id}
-      />
-    ) : (
-      <LoadingCarouselCard />
-    )
-
   return (
     <Wrapper>
       <EnterpriseCarousel
         activeIndex={activeIndex}
-        enterprises={
-          doneLoading()
-            ? signerEnterprises?.map((enterprise) => ({
-                id: enterprise.id,
-                component: showEnterpriseCard(enterprise),
-              }))
-            : undefined
-        }
+        enterprises={signerEnterprises}
         loading={connected && signerEnterprises === undefined}
         onActiveSlidesChange={onSignerSlidesChange}
         overlay={overlay()}

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
@@ -66,6 +66,7 @@ const MyEnterprises: React.FC = () => {
         loading={connected && signerEnterprises === undefined}
         onActiveSlidesChange={onSignerSlidesChange}
         overlay={overlay()}
+        title="Choose your Enterprise"
       />
     </Wrapper>
   )

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
@@ -16,9 +16,10 @@ const Wrapper = styled.div`
   width: 100%;
 `
 const MyEnterprises: React.FC = () => {
-  const { enterprisesStore, web3Store } = useRootStore()
+  const { signerStore, web3Store } = useRootStore()
   const { connected } = web3Store
-  const { signerEnterprises, setSignerSlides, signerActiveEnterprise } = enterprisesStore
+  const { activeIndex, onSignerSlidesChange, signerEnterprises, signerActiveEnterprise } =
+    signerStore
 
   const doneLoading = (): boolean => isFirstEnterpriseLoaded(signerEnterprises)
 
@@ -45,7 +46,6 @@ const MyEnterprises: React.FC = () => {
       <EnterpriseCard
         enterprise={enterprise}
         active={signerActiveEnterprise && enterprise?.id === signerActiveEnterprise?.id}
-        onClick={enterprisesStore.setSignerEnterpriseActiveId}
       />
     ) : (
       <LoadingCarouselCard />
@@ -54,6 +54,7 @@ const MyEnterprises: React.FC = () => {
   return (
     <Wrapper>
       <EnterpriseCarousel
+        activeIndex={activeIndex}
         enterprises={
           doneLoading()
             ? signerEnterprises?.map((enterprise) => ({
@@ -63,7 +64,7 @@ const MyEnterprises: React.FC = () => {
             : undefined
         }
         loading={connected && signerEnterprises === undefined}
-        onActiveSlidesChange={setSignerSlides}
+        onActiveSlidesChange={onSignerSlidesChange}
         overlay={overlay()}
       />
     </Wrapper>

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/MyEnterprises.tsx
@@ -7,7 +7,7 @@ import { spacingIncrement } from '../../utils/theme/utils'
 import ConnectButton from '../connect/ConnectButton'
 
 const Wrapper = styled.div`
-  margin: ${spacingIncrement(44)} 0;
+  margin-top: ${spacingIncrement(44)};
   position: relative;
   width: 100%;
 `

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/SearchCompetition.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/SearchCompetition.tsx
@@ -9,7 +9,6 @@ type Props = {
 }
 
 const InnerWrapper = styled.form`
-  max-width: ${spacingIncrement(400)};
   width: 100%;
 `
 
@@ -24,6 +23,7 @@ const Labels = styled.p`
 const Wrapper = styled.div`
   ${centered}
   margin-bottom: ${spacingIncrement(18)};
+  width: 100%;
 `
 
 const SearchCompetition: React.FC<Props> = ({ label }) => {

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/SearchCompetition.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/SearchCompetition.tsx
@@ -16,12 +16,12 @@ const Wrapper = styled.div`
 
 const SearchCompetition: React.FC = () => {
   const [query, setQuery] = useState('')
-  const { enterprisesStore } = useRootStore()
-  const { competitionEnterprises, searchCompetitionQuery } = enterprisesStore
+  const { competitionStore } = useRootStore()
+  const { competitionEnterprises, searchCompetition, searchCompetitionQuery } = competitionStore
 
   const handleSearch = (e: React.FormEvent): void => {
     e.preventDefault()
-    enterprisesStore.searchCompetition(query)
+    searchCompetition(query)
   }
   return (
     <Wrapper>
@@ -33,7 +33,7 @@ const SearchCompetition: React.FC = () => {
           buttonProps={{
             children: 'Search',
             disabled: Number.isNaN(+query),
-            onClick: (): void => enterprisesStore.searchCompetition(query),
+            onClick: (): void => searchCompetition(query),
             loading: Boolean(searchCompetitionQuery) && competitionEnterprises === undefined,
           }}
         />

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/SearchCompetition.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/SearchCompetition.tsx
@@ -1,39 +1,57 @@
-import { useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import styled from 'styled-components'
 import { centered, spacingIncrement } from '../../utils/theme/utils'
 import Input from '../../components/Input'
 import { useRootStore } from '../../context/RootStoreProvider'
 
+type Props = {
+  label?: string
+}
+
 const InnerWrapper = styled.form`
   max-width: ${spacingIncrement(400)};
   width: 100%;
 `
 
-const Wrapper = styled.div`
-  ${centered}
+const Labels = styled.p`
+  color: ${({ theme }): string => theme.color.white};
+  font-size: ${({ theme }): string => theme.fontSize.base};
+  font-weight: ${({ theme }): number => theme.fontWeight.bold};
+  margin-bottom: ${spacingIncrement(8)};
+  text-align: center;
 `
 
-const SearchCompetition: React.FC = () => {
-  const [query, setQuery] = useState('')
+const Wrapper = styled.div`
+  ${centered}
+  margin-bottom: ${spacingIncrement(18)};
+`
+
+const SearchCompetition: React.FC<Props> = ({ label }) => {
   const { competitionStore } = useRootStore()
-  const { competitionEnterprises, searchCompetition, searchCompetitionQuery } = competitionStore
+  const {
+    competitionEnterprises,
+    localQuery,
+    setLocalQuery,
+    searchCompetition,
+    searchCompetitionQuery,
+  } = competitionStore
 
   const handleSearch = (e: React.FormEvent): void => {
     e.preventDefault()
-    searchCompetition(query)
+    searchCompetition()
   }
   return (
     <Wrapper>
       <InnerWrapper onSubmit={handleSearch}>
+        <Labels>{label}</Labels>
         <Input
-          onChange={(e): void => setQuery(e.target.value)}
+          onChange={(e): void => setLocalQuery(e.target.value)}
           placeholder="Wallet address/Enterprise ID"
-          value={query}
+          value={localQuery}
           buttonProps={{
             children: 'Search',
-            disabled: Number.isNaN(+query),
-            onClick: (): void => searchCompetition(query),
+            disabled: Number.isNaN(+localQuery),
+            onClick: searchCompetition,
             loading: Boolean(searchCompetitionQuery) && competitionEnterprises === undefined,
           }}
         />

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
@@ -18,9 +18,11 @@ const toKeepOrBurn = (id?: number, keepId?: number): string => {
 }
 
 const Acquire: React.FC = () => {
-  const { acquireStore, acquisitionRoyaleContractStore, enterprisesStore } = useRootStore()
+  const { acquireStore, acquisitionRoyaleContractStore, competitionStore, signerStore } =
+    useRootStore()
   const { acquireButtonProps, acquireBalances, acquireCosts, acquireComparisons } = acquireStore
-  const { competitionActiveEnterprise, signerActiveEnterprise } = enterprisesStore
+  const { competitionActiveEnterprise } = competitionStore
+  const { signerActiveEnterprise } = signerStore
   const { acquire, acquireKeepId, acquiring, setAcquireKeepId } = acquisitionRoyaleContractStore
 
   const handleAcquire = useCallback(async (): Promise<void> => {

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
@@ -77,7 +77,7 @@ const Acquire: React.FC = () => {
       title="Acquire"
     >
       <MyEnterprises />
-      <Competition />
+      <Competition label="Search for Enterprises to Acquire:" />
     </ActionCard>
   )
 }

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
@@ -7,6 +7,7 @@ import { useRootStore } from '../../../context/RootStoreProvider'
 import { INSUFFICIENT_MATIC } from '../../../utils/common-utils'
 import ActionCard from '../ActionCard'
 import { acquireActionDescription } from '../Descriptions'
+import MyEnterprises from '../MyEnterprises'
 
 const EnterpriseLabel = styled.span`
   font-size: ${({ theme }): string => theme.fontSize.base};
@@ -73,7 +74,9 @@ const Acquire: React.FC = () => {
       loading={acquiring}
       lowMatic={acquireButtonProps.children === INSUFFICIENT_MATIC}
       title="Acquire"
-    />
+    >
+      <MyEnterprises />
+    </ActionCard>
   )
 }
 

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/Acquire.tsx
@@ -6,6 +6,7 @@ import EnterpriseRadio from '../../../components/EnterpriseRadio'
 import { useRootStore } from '../../../context/RootStoreProvider'
 import { INSUFFICIENT_MATIC } from '../../../utils/common-utils'
 import ActionCard from '../ActionCard'
+import Competition from '../Competition'
 import { acquireActionDescription } from '../Descriptions'
 import MyEnterprises from '../MyEnterprises'
 
@@ -76,6 +77,7 @@ const Acquire: React.FC = () => {
       title="Acquire"
     >
       <MyEnterprises />
+      <Competition />
     </ActionCard>
   )
 }

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/AcquireStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/acquire/AcquireStore.ts
@@ -23,7 +23,7 @@ export class AcquireStore {
   }
 
   get acquireBalances(): CostBalance[] | undefined {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     const { balance } = this.root.runwayPointsContractStore
     if (!signerActiveEnterprise) return undefined
     const rpCostBalanceEnterprise = makeRPCostBalanceWallet(balance ?? 0)
@@ -37,8 +37,8 @@ export class AcquireStore {
     const { acquireCost } = this.root.acquireRPCostContractStore
     const { balance } = this.root.runwayPointsContractStore
     const { rpRequiredForDamage } = this.root.competeV1ContractStore
-    const { signerEnterprises, signerActiveEnterprise, competitionActiveEnterprise } =
-      this.root.enterprisesStore
+    const { signerEnterprises, signerActiveEnterprise } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     const { acquireKeepId } = this.root.acquisitionRoyaleContractStore
 
     if (signerEnterprises && signerEnterprises.length === 0)
@@ -75,7 +75,8 @@ export class AcquireStore {
   }
 
   get acquireComparisons(): ComparisonProps[] | undefined {
-    const { competitionActiveEnterprise, signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     const { acquireKeepId, getNewRpPerDay, passiveRpPerDay, acquisitionImmunityPeriod } =
       this.root.acquisitionRoyaleContractStore
     const { rpRequiredForDamage } = this.root.competeV1ContractStore
@@ -154,7 +155,7 @@ export class AcquireStore {
   }
 
   get acquireCosts(): CostBalance[] | undefined {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     const { acquireCost } = this.root.acquireRPCostContractStore
     const { rpRequiredForDamage } = this.root.competeV1ContractStore
     // RP cost can be 0 when no competition is selected

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Compete.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Compete.tsx
@@ -6,6 +6,7 @@ import Input from '../../../components/Input'
 import { competeActionDescription } from '../Descriptions'
 import { useRootStore } from '../../../context/RootStoreProvider'
 import { numberInput } from '../../../utils/number-utils'
+import MyEnterprises from '../MyEnterprises'
 
 const CompeteAction: React.FC = () => {
   const { actionsStore, acquisitionRoyaleContractStore } = useRootStore()
@@ -47,7 +48,9 @@ const CompeteAction: React.FC = () => {
       input={input}
       loading={competing}
       title="Compete"
-    />
+    >
+      <MyEnterprises />
+    </ActionCard>
   )
 }
 

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Compete.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Compete.tsx
@@ -51,7 +51,7 @@ const CompeteAction: React.FC = () => {
       title="Compete"
     >
       <MyEnterprises />
-      <Competition />
+      <Competition label="Search for Enterprises to Compete:" />
     </ActionCard>
   )
 }

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Compete.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Compete.tsx
@@ -7,6 +7,7 @@ import { competeActionDescription } from '../Descriptions'
 import { useRootStore } from '../../../context/RootStoreProvider'
 import { numberInput } from '../../../utils/number-utils'
 import MyEnterprises from '../MyEnterprises'
+import Competition from '../Competition'
 
 const CompeteAction: React.FC = () => {
   const { actionsStore, acquisitionRoyaleContractStore } = useRootStore()
@@ -50,6 +51,7 @@ const CompeteAction: React.FC = () => {
       title="Compete"
     >
       <MyEnterprises />
+      <Competition />
     </ActionCard>
   )
 }

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/actions/DepositRp.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/actions/DepositRp.tsx
@@ -6,6 +6,7 @@ import { useRootStore } from '../../../context/RootStoreProvider'
 import { numberInput } from '../../../utils/number-utils'
 import ActionCard from '../ActionCard'
 import { depositActionDescription } from '../Descriptions'
+import MyEnterprises from '../MyEnterprises'
 
 const DepositRp: React.FC = () => {
   const { actionsStore, acquisitionRoyaleContractStore } = useRootStore()
@@ -49,7 +50,9 @@ const DepositRp: React.FC = () => {
       input={input}
       loading={depositing}
       title="Deposit RP"
-    />
+    >
+      <MyEnterprises />
+    </ActionCard>
   )
 }
 

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Rename.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Rename.tsx
@@ -5,6 +5,7 @@ import ActionCard from '../ActionCard'
 import { renameActionDescription } from '../Descriptions'
 import Input from '../../../components/Input'
 import { useRootStore } from '../../../context/RootStoreProvider'
+import MyEnterprises from '../MyEnterprises'
 
 const Rename: React.FC = () => {
   const { acquisitionRoyaleContractStore, actionsStore } = useRootStore()
@@ -40,7 +41,9 @@ const Rename: React.FC = () => {
       input={input}
       loading={renaming}
       title="Rename"
-    />
+    >
+      <MyEnterprises />
+    </ActionCard>
   )
 }
 

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Revive.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/actions/Revive.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react-lite'
 import ActionCard from '../ActionCard'
 import { reviveActionDescription } from '../Descriptions'
 import { useRootStore } from '../../../context/RootStoreProvider'
+import Competition from '../Competition'
 
 const Revive: React.FC = () => {
   const { actionsStore, acquisitionRoyaleContractStore } = useRootStore()
@@ -23,7 +24,9 @@ const Revive: React.FC = () => {
       description={reviveActionDescription}
       loading={acquisitionRoyaleContractStore.reviving}
       title="Revive"
-    />
+    >
+      <Competition label="Search for Enterprises to Revive:" />
+    </ActionCard>
   )
 }
 

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/actions/WithdrawRp.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/actions/WithdrawRp.tsx
@@ -6,6 +6,7 @@ import { useRootStore } from '../../../context/RootStoreProvider'
 import { numberInput } from '../../../utils/number-utils'
 import ActionCard from '../ActionCard'
 import { withdrawActionDescription } from '../Descriptions'
+import MyEnterprises from '../MyEnterprises'
 
 const WithdrawRp: React.FC = () => {
   const { acquisitionRoyaleContractStore, actionsStore } = useRootStore()
@@ -52,7 +53,9 @@ const WithdrawRp: React.FC = () => {
       input={input}
       loading={withdrawing}
       title="Withdraw RP"
-    />
+    >
+      <MyEnterprises />
+    </ActionCard>
   )
 }
 

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/merge/Merge.tsx
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/merge/Merge.tsx
@@ -7,22 +7,23 @@ import { mergeActionDescription } from '../Descriptions'
 import { useRootStore } from '../../../context/RootStoreProvider'
 import { INSUFFICIENT_MATIC } from '../../../utils/common-utils'
 import { Enterprise } from '../../../types/enterprise.types'
+import MyEnterprises from '../MyEnterprises'
 
 const Merge: React.FC = () => {
-  const { acquisitionRoyaleContractStore, enterprisesStore, mergeStore } = useRootStore()
+  const { acquisitionRoyaleContractStore, signerStore, mergeStore } = useRootStore()
   const [shouldClear, setShouldClear] = useState(false)
   const { mergeButtonProps, mergeBalances, mergeCosts, mergeComparisons } = mergeStore
-  const { signerActiveEnterprise, signerEnterprises } = enterprisesStore
+  const { setMergeTargetId, signerActiveEnterprise, signerEnterprises } = signerStore
   const { merging } = acquisitionRoyaleContractStore
 
   const onSelect = (target: unknown): void => {
     const id: number = target as number
-    enterprisesStore.setMergeTargetId(id)
+    setMergeTargetId(id)
   }
 
   const onClear = (): void => {
     setShouldClear(false)
-    enterprisesStore.setMergeTargetId(undefined)
+    setMergeTargetId(undefined)
   }
 
   const onMerge = useCallback(async () => {
@@ -83,7 +84,9 @@ const Merge: React.FC = () => {
       loading={merging}
       lowMatic={mergeButtonProps.children === INSUFFICIENT_MATIC}
       title="Merge"
-    />
+    >
+      <MyEnterprises />
+    </ActionCard>
   )
 }
 

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/merge/MergeStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/merge/MergeStore.ts
@@ -29,7 +29,7 @@ export class MergeStore {
     const { balance } = this.root.runwayPointsContractStore
     const { mergeCost } = this.root.mergeRPCostContractStore
     const { mergeTargetEnterprise, signerActiveEnterprise, signerEnterprises } =
-      this.root.enterprisesStore
+      this.root.signerStore
     if (signerEnterprises && signerEnterprises.length === 0)
       return { disabled: true, children: 'No owned Enterprise' }
 
@@ -49,7 +49,7 @@ export class MergeStore {
   }
 
   get mergeComparisons(): ComparisonProps[] | undefined {
-    const { mergeTargetEnterprise, signerActiveEnterprise } = this.root.enterprisesStore
+    const { mergeTargetEnterprise, signerActiveEnterprise } = this.root.signerStore
     const { getNewRpPerDay, mergerImmunityPeriod, passiveRpPerDay } =
       this.root.acquisitionRoyaleContractStore
     if (

--- a/apps/frontend/acquisition-royale-home/src/features/mvp/stores/RpShopStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/features/mvp/stores/RpShopStore.ts
@@ -56,7 +56,7 @@ export class RpShopStore {
   get rpShopComparisons(): ComparisonProps[] | undefined {
     const { balance } = this.root.runwayPointsContractStore
     const { rebrandBalance, renameBalance, reviveBalance } = this.root.consumablesContractStore
-    const { enterprisesBalance } = this.root.enterprisesStore
+    const { enterprisesBalance } = this.root.signerStore
     const { quantity, rpCost, selectedConsumable } = this.root.acquisitionRoyaleRPShopContractStore
     if (!selectedConsumable || balance === undefined || rpCost === undefined) return undefined
     const { name, balance: consumableBalance } = getCorrectConsumableBalance(selectedConsumable, {

--- a/apps/frontend/acquisition-royale-home/src/stores/AcquisitionRoyaleContractStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/AcquisitionRoyaleContractStore.ts
@@ -269,7 +269,8 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
   // write contract
 
   async acquire(): Promise<boolean | undefined> {
-    const { competitionActiveEnterprise, signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     if (
       this.acquireKeepId !== undefined &&
       competitionActiveEnterprise !== undefined &&
@@ -290,9 +291,9 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
         await tx.wait()
 
         runInAction(() => {
-          this.root.enterprisesStore.setSignerEnterpriseActiveId(this.acquireKeepId)
-          this.root.enterprisesStore.setCompetitionEnterpriseActiveId(undefined)
-          this.root.enterprisesStore.searchCompetition('')
+          this.root.signerStore.setSignerEnterpriseActiveId(this.acquireKeepId)
+          this.root.competitionStore.setCompetitionEnterpriseActiveId(undefined)
+          this.root.competitionStore.searchCompetition('')
         })
         return true
       } catch (error) {
@@ -308,7 +309,8 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
   }
 
   async compete(): Promise<boolean | undefined> {
-    const { signerActiveEnterprise, competitionActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     if (signerActiveEnterprise !== undefined && competitionActiveEnterprise !== undefined) {
       try {
         this.competing = true
@@ -332,7 +334,7 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
   }
 
   async deposit(): Promise<boolean | undefined> {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     if (
       signerActiveEnterprise !== undefined &&
       this.depositAmount &&
@@ -362,7 +364,7 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
   }
 
   async merge(): Promise<boolean | undefined> {
-    const { signerActiveEnterprise, mergeTargetEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise, mergeTargetEnterprise } = this.root.signerStore
     if (
       signerActiveEnterprise !== undefined &&
       mergeTargetEnterprise !== undefined &&
@@ -376,7 +378,7 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
           mergeTargetEnterprise.id,
         ])
         await tx.wait()
-        this.root.enterprisesStore.setMergeTargetId(undefined)
+        this.root.signerStore.setMergeTargetId(undefined)
         return true
       } catch (error) {
         this.root.toastStore.errorToast('merge', error)
@@ -390,7 +392,7 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
   }
 
   async rename(): Promise<boolean | undefined> {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     try {
       if (this.newName.length > 0 && signerActiveEnterprise !== undefined) {
         this.renaming = true
@@ -416,7 +418,7 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
 
   async revive(): Promise<boolean | undefined> {
     try {
-      const { competitionActiveEnterprise } = this.root.enterprisesStore
+      const { competitionActiveEnterprise } = this.root.competitionStore
       if (competitionActiveEnterprise !== undefined) {
         if (!competitionActiveEnterprise.burned) {
           notification.error({ message: 'Cannot revive, enterprise is active!' })
@@ -429,8 +431,8 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
           message: `${competitionActiveEnterprise.name} is now yours! 🎉`,
         })
         runInAction(() => {
-          this.root.enterprisesStore.setCompetitionEnterpriseActiveId(undefined)
-          this.root.enterprisesStore.searchCompetition('')
+          this.root.competitionStore.setCompetitionEnterpriseActiveId(undefined)
+          this.root.competitionStore.searchCompetition('')
         })
         return true
       }
@@ -445,7 +447,7 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
   }
 
   async rebrand(): Promise<boolean | undefined> {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     try {
       if (signerActiveEnterprise) {
         if (!ethers.utils.isAddress(this.rebrandAddress)) {
@@ -472,7 +474,7 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
   }
 
   async withdraw(): Promise<boolean | undefined> {
-    const { signerActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
     if (
       signerActiveEnterprise !== undefined &&
       this.withdrawAmount &&

--- a/apps/frontend/acquisition-royale-home/src/stores/AcquisitionRoyaleContractStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/AcquisitionRoyaleContractStore.ts
@@ -293,7 +293,8 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
         runInAction(() => {
           this.root.signerStore.setSignerEnterpriseActiveId(this.acquireKeepId)
           this.root.competitionStore.setCompetitionEnterpriseActiveId(undefined)
-          this.root.competitionStore.searchCompetition('')
+          this.root.competitionStore.setLocalQuery('')
+          this.root.competitionStore.searchCompetition()
         })
         return true
       } catch (error) {
@@ -432,7 +433,8 @@ export class AcquisitionRoyaleContractStore extends ContractStore<RootStore, Sup
         })
         runInAction(() => {
           this.root.competitionStore.setCompetitionEnterpriseActiveId(undefined)
-          this.root.competitionStore.searchCompetition('')
+          this.root.competitionStore.setLocalQuery('')
+          this.root.competitionStore.searchCompetition()
         })
         return true
       }

--- a/apps/frontend/acquisition-royale-home/src/stores/CompeteV1ContractStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/CompeteV1ContractStore.ts
@@ -20,7 +20,8 @@ export class CompeteV1ContractStore extends ContractStore<RootStore, SupportedCo
       latestRpRequiredForDamage: computed,
     })
     autorun(() => {
-      const { signerActiveEnterprise, competitionActiveEnterprise } = this.root.enterprisesStore
+      const { signerActiveEnterprise } = this.root.signerStore
+      const { competitionActiveEnterprise } = this.root.competitionStore
       const { competeAddress } = this.root.acquisitionRoyaleContractStore
       if (competeAddress !== undefined && this.contract?.address !== competeAddress) {
         this.updateAddress(competeAddress)
@@ -56,7 +57,8 @@ export class CompeteV1ContractStore extends ContractStore<RootStore, SupportedCo
   }
 
   get damage(): number | undefined {
-    const { signerActiveEnterprise, competitionActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     const { competeRp } = this.root.acquisitionRoyaleContractStore
     if (signerActiveEnterprise === undefined || competitionActiveEnterprise === undefined) {
       return undefined
@@ -72,7 +74,8 @@ export class CompeteV1ContractStore extends ContractStore<RootStore, SupportedCo
   }
 
   get latestRpRequiredForDamage(): number | undefined {
-    const { signerActiveEnterprise, competitionActiveEnterprise } = this.root.enterprisesStore
+    const { signerActiveEnterprise } = this.root.signerStore
+    const { competitionActiveEnterprise } = this.root.competitionStore
     if (
       signerActiveEnterprise !== undefined &&
       competitionActiveEnterprise?.stats.rp !== undefined

--- a/apps/frontend/acquisition-royale-home/src/stores/CompetitionStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/CompetitionStore.ts
@@ -1,0 +1,80 @@
+import { notification } from 'antd'
+import { BigNumber } from 'ethers'
+import { isAddress } from 'ethers/lib/utils'
+import { makeAutoObservable } from 'mobx'
+import { RootStore } from './RootStore'
+import { Enterprise, Enterprises } from '../types/enterprise.types'
+
+export class CompetitionStore {
+  activeEnterpriseId?: number
+  searchCompetitionQuery?: string
+  slides: number
+  constructor(public root: RootStore) {
+    this.slides = 0
+    makeAutoObservable(this, {}, { autoBind: true })
+  }
+
+  clearEnterprises(): void {
+    this.activeEnterpriseId = undefined
+    this.root.acquisitionRoyaleContractStore.setAcquireKeepId(undefined)
+    this.slides = 0
+  }
+
+  onSlidesChange({ enterpriseId, slides }: { enterpriseId?: number; slides: number }): void {
+    this.setCompetitionEnterpriseActiveId(enterpriseId)
+    if (slides > this.slides) this.slides = slides
+  }
+
+  setCompetitionEnterpriseActiveId(id?: number): void {
+    this.activeEnterpriseId = id
+  }
+
+  searchCompetition(query: string): void {
+    if (
+      this.root.web3Store.signerState.address !== undefined &&
+      query.toLowerCase() === this.root.web3Store.signerState.address.toLowerCase()
+    ) {
+      notification.error({ message: 'Cannot search your own address!' })
+      return
+    }
+    this.clearEnterprises()
+    this.searchCompetitionQuery = query
+  }
+
+  get competitionActiveEnterprise(): Enterprise | undefined {
+    if (this.activeEnterpriseId !== undefined && this.competitionEnterprises) {
+      const activeIndex = this.competitionEnterprises.findIndex(
+        (enterprise) => enterprise && enterprise.id === this.activeEnterpriseId
+      )
+      return this.competitionEnterprises[activeIndex]
+    }
+    return undefined
+  }
+
+  get competitionEnterprises(): Enterprises | undefined {
+    const { address } = this.root.web3Store
+    if (
+      this.searchCompetitionQuery === undefined ||
+      this.searchCompetitionQuery.length === 0 ||
+      (address && address.toLowerCase() === this.searchCompetitionQuery.toLowerCase())
+    ) {
+      return []
+    }
+    if (isAddress(this.searchCompetitionQuery))
+      return this.root.enterprisesStore.lazyLoad(this.searchCompetitionQuery, this.slides)
+    if (!Number.isNaN(+this.searchCompetitionQuery)) {
+      const id = BigNumber.from(this.searchCompetitionQuery)
+      const rawIsMinted = this.root.acquisitionRoyaleContractStore.isMinted(id)
+      if (rawIsMinted === undefined) return undefined
+      if (!rawIsMinted[0]) return []
+      const enterpriseBasic = this.root.enterprisesStore.getEnterpriseById(
+        BigNumber.from(this.searchCompetitionQuery)
+      )
+      if (!enterpriseBasic) return undefined
+      const enterpriseDetails = this.root.enterprisesStore.getEnterpriseDetails(enterpriseBasic)
+      if (!enterpriseDetails) return undefined
+      return [{ ...enterpriseBasic, ...enterpriseDetails }]
+    }
+    return []
+  }
+}

--- a/apps/frontend/acquisition-royale-home/src/stores/EnterprisesStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/EnterprisesStore.ts
@@ -1,34 +1,18 @@
-import { notification } from 'antd'
 import { BigNumber, ethers } from 'ethers'
-import { action, autorun, makeAutoObservable, observable, runInAction } from 'mobx'
+import { makeAutoObservable } from 'mobx'
 import { RootStore } from './RootStore'
 import { getRawEnterprise, getReadableEnterpriseBasic } from './utils/enterprise-utils'
 import { calculateRpPerDay } from './utils/common-utils'
 import { formatArt } from './utils/branding-utils'
-import {
-  Enterprise,
-  EnterpriseBasic,
-  EnterpriseDetails,
-  Enterprises,
-} from '../types/enterprise.types'
+import { EnterpriseBasic, EnterpriseDetails, Enterprises } from '../types/enterprise.types'
 import { EMPTY_CONTRACT_ADDRESS, SEC_IN_MS } from '../lib/constants'
-import { transformRawNumber } from '../utils/number-utils'
-
-type LazyLoadUpdater = (enterprise: Enterprise, index: number, balance: number) => unknown
-type LazyLoadOptions = {
-  forceLoadBasic?: boolean
-  loadUntil?: number
-  updater?: LazyLoadUpdater
-}
 
 export class EnterpriseStore {
   root: RootStore
-  competitionEnterprises?: Enterprises
   competitionActiveEnterpriseId?: number
   competitionSlides: number
   mergeTargetId?: number
   searchCompetitionQuery?: string
-  signerEnterprises?: Enterprises
   signerActiveEnterpriseId?: number
   signerSlides: number
 
@@ -36,152 +20,8 @@ export class EnterpriseStore {
     this.root = root
     this.competitionSlides = 0
     this.signerSlides = 0
-    makeAutoObservable(
-      this,
-      {
-        clearCompetitionEnterprises: action.bound,
-        clearSignerEnterprises: action.bound,
-        competitionEnterprises: observable,
-        noCompetition: action.bound,
-        setCompetitionEnterpriseActiveId: action.bound,
-        setMergeTargetId: action.bound,
-        setSignerEnterpriseActiveId: action.bound,
-        setSignerSlides: action.bound,
-        signerEnterprises: observable,
-        updateCompetitionEnterprises: action.bound,
-        updateSignerEnterprises: action.bound,
-      },
-      { autoBind: true }
-    )
-
-    autorun(() => {
-      this.loadSignerEnterprises()
-      this.loadCompetitionEnterprises()
-    })
+    makeAutoObservable(this, {}, { autoBind: true })
   }
-
-  clearCompetitionEnterprises(): void {
-    this.competitionActiveEnterpriseId = undefined
-    this.competitionEnterprises = undefined
-    this.root.acquisitionRoyaleContractStore.setAcquireKeepId(undefined)
-  }
-
-  clearSignerEnterprises(): void {
-    this.signerActiveEnterpriseId = undefined
-    this.signerEnterprises = undefined
-    this.setMergeTargetId(undefined)
-  }
-
-  // when this returns undefined, the address is changed, hence the cache should be cleared
-  lazyLoadEnterprisesByAddress(
-    address: string,
-    { forceLoadBasic, loadUntil, updater }: LazyLoadOptions
-  ): number | undefined {
-    const { acquisitionRoyaleContractStore } = this.root
-    const rawBalance = acquisitionRoyaleContractStore.balanceOf(address)
-    if (rawBalance === undefined) return undefined
-    const balance = rawBalance[0].toNumber()
-
-    let shouldLoadUntil = balance
-
-    // if forceLoadBasic is false, we can loop only those that are within loadUntil
-    if (!forceLoadBasic && loadUntil !== undefined && balance > loadUntil) {
-      shouldLoadUntil = loadUntil
-    }
-    // start lazy loading enterprises
-    for (let i = 0; i < shouldLoadUntil; i++) {
-      // every index in this loop will require at least the basic info
-      // so we can fetch basic info
-      // then check whether details is required
-      const enterpriseBasic = this.getEnterpriseBasic(address, i)
-      if (enterpriseBasic) {
-        // once we get the basic info,
-        // check whether we need details and get the details
-        let enterpriseDetails: EnterpriseDetails = {}
-        if (loadUntil === undefined || i < loadUntil) {
-          // fetch details with basic info
-          // update from here enterpriseDetails when we have everything
-          const details = this.getEnterpriseDetails(enterpriseBasic)
-          if (details) {
-            enterpriseDetails = details
-          }
-        }
-
-        // then use updater to update caller
-        // so that caller can update their own data
-        // e.g. signer's list will update signerEnterprises while competition list will update competitionEnterprises
-        if (updater) {
-          updater({ ...enterpriseBasic, ...enterpriseDetails }, i, balance)
-        }
-      }
-    }
-
-    return balance
-  }
-
-  loadCompetitionEnterprises(): void {
-    if (this.searchCompetitionQuery === undefined || this.searchCompetitionQuery.length === 0) {
-      this.clearCompetitionEnterprises()
-      return
-    }
-    if (ethers.utils.isAddress(this.searchCompetitionQuery)) {
-      // empty list if searching own address
-      if (this.root.web3Store.address === this.searchCompetitionQuery) {
-        this.noCompetition()
-      } else {
-        this.lazyLoadEnterprisesByAddress(this.searchCompetitionQuery, {
-          forceLoadBasic: false,
-          loadUntil: this.competitionSlides,
-          updater: this.updateCompetitionEnterprises,
-        })
-      }
-    } else if (!Number.isNaN(+this.searchCompetitionQuery)) {
-      const rawIsMinted = this.root.acquisitionRoyaleContractStore.isMinted(
-        BigNumber.from(this.searchCompetitionQuery)
-      )
-      if (rawIsMinted === undefined) return
-      // if id that's being searched is not minted, don't need to proceed
-      if (!rawIsMinted[0]) {
-        this.noCompetition()
-      } else {
-        const enterpriseBasic = this.getEnterpriseById(BigNumber.from(this.searchCompetitionQuery))
-        if (enterpriseBasic) {
-          const enterpriseDetails = this.getEnterpriseDetails(enterpriseBasic)
-          if (enterpriseDetails) {
-            runInAction(() => {
-              this.competitionEnterprises = [{ ...enterpriseBasic, ...enterpriseDetails }]
-              this.competitionActiveEnterpriseId = enterpriseBasic.id
-            })
-          }
-        }
-      }
-    }
-  }
-
-  loadSignerEnterprises(): void {
-    const { address } = this.root.web3Store
-    if (address) {
-      const enterpriseBalance = this.lazyLoadEnterprisesByAddress(address, {
-        forceLoadBasic: true,
-        loadUntil: this.signerSlides,
-        updater: this.updateSignerEnterprises,
-      })
-      if (enterpriseBalance === undefined) this.clearCompetitionEnterprises()
-      // updater will not update anything if enterpriseBalance is 0 because there's nothing to update
-      // but we must update this.signerEnterprises to [] so the UI does not stay in loading state
-      if (enterpriseBalance === 0) {
-        runInAction(() => {
-          this.signerEnterprises = []
-        })
-      }
-    }
-  }
-  // to get complete information of an enterprise, we will group an enterprise's required calls into 2 functions
-  // getEnterpriseBasic will get the id, name and rp (and other info that don't require API call) of an Enterprise
-  // getEnterpriseDetails will get rest of the information like art, immunity and so on
-  // this is because for Merge action, we cannot lazy load Enterprise's name as we need complete list for them to choose from
-  // but we can lazy load the enterprise's NFT and other stats as those are only used if user selects them from the list
-  // as for competition analysis, we can basically lazy load everything
 
   getEnterpriseBasic(address: string, index: number): EnterpriseBasic | undefined {
     const { acquisitionRoyaleContractStore } = this.root
@@ -229,101 +69,25 @@ export class EnterpriseStore {
     return undefined
   }
 
-  noCompetition(): void {
-    this.competitionActiveEnterpriseId = undefined
-    this.competitionEnterprises = []
-  }
+  lazyLoad(address: string, loadUntil: number): Enterprises | undefined {
+    const { acquisitionRoyaleContractStore } = this.root
+    const rawBalance = acquisitionRoyaleContractStore.balanceOf(address)
+    if (rawBalance === undefined) return undefined
+    const balance = rawBalance[0].toNumber()
 
-  searchCompetition(query: string): void {
-    if (
-      this.root.web3Store.signerState.address !== undefined &&
-      query === this.root.web3Store.signerState.address
-    ) {
-      notification.error({ message: 'Cannot search your own address!' })
-      return
+    const enterprises = []
+    for (let i = 0; i < balance; i++) {
+      const basic = this.getEnterpriseBasic(address, i)
+      if (basic) {
+        let enterprise = basic
+        if (i < loadUntil) {
+          const details = this.getEnterpriseDetails(basic)
+          if (details !== undefined) enterprise = { ...basic, ...details }
+        }
+        enterprises.push(enterprise)
+      }
     }
-    this.clearCompetitionEnterprises()
-    this.searchCompetitionQuery = query
-  }
-
-  setCompetitionEnterpriseActiveId(id?: number): void {
-    this.competitionActiveEnterpriseId = id
-  }
-
-  setCompetitionSlides(slides: number): void {
-    this.competitionSlides = slides
-  }
-
-  setMergeTargetId(id?: number): void {
-    this.mergeTargetId = id
-  }
-
-  setSignerEnterpriseActiveId(id?: number): void {
-    this.signerActiveEnterpriseId = id
-    if (id !== undefined && this.mergeTargetId === id) {
-      this.setMergeTargetId(undefined)
-    }
-  }
-
-  setSignerSlides(slides: number): void {
-    this.signerSlides = slides
-  }
-
-  updateCompetitionEnterprises(enterprise: Enterprise, index: number, balance: number): void {
-    this.competitionEnterprises = this.competitionEnterprises || []
-    this.competitionEnterprises.length = balance
-    // auto select first result
-    const shouldAutoSelect = index === 0 && this.competitionActiveEnterpriseId === undefined
-    this.competitionActiveEnterpriseId = shouldAutoSelect
-      ? enterprise.id
-      : this.competitionActiveEnterpriseId
-    this.competitionEnterprises[index] = {
-      ...this.competitionEnterprises[index],
-      ...enterprise,
-    }
-  }
-
-  updateSignerEnterprises(enterprise: Enterprise, index: number, balance: number): void {
-    this.signerEnterprises = this.signerEnterprises || []
-    this.signerEnterprises.length = balance
-    const shouldAutoSelect = index === 0 && this.signerActiveEnterpriseId === undefined
-    this.signerActiveEnterpriseId = shouldAutoSelect ? enterprise.id : this.signerActiveEnterpriseId
-    this.signerEnterprises[index] = { ...this.signerEnterprises[index], ...enterprise }
-  }
-
-  get enterprisesBalance(): number | undefined {
-    const { address } = this.root.web3Store
-    if (address === undefined) return undefined
-    return transformRawNumber(this.root.acquisitionRoyaleContractStore.balanceOf(address))
-  }
-  get competitionActiveEnterprise(): Enterprise | undefined {
-    if (this.competitionActiveEnterpriseId !== undefined && this.competitionEnterprises) {
-      const activeIndex = this.competitionEnterprises.findIndex(
-        (enterprise) => enterprise && enterprise.id === this.competitionActiveEnterpriseId
-      )
-      return this.competitionEnterprises[activeIndex]
-    }
-    return undefined
-  }
-
-  get mergeTargetEnterprise(): Enterprise | undefined {
-    if (this.mergeTargetId !== undefined && this.signerEnterprises) {
-      const mergeIndex = this.signerEnterprises?.findIndex(
-        (enterprise) => enterprise && enterprise.id === this.mergeTargetId
-      )
-
-      return this.signerEnterprises[mergeIndex]
-    }
-    return undefined
-  }
-
-  get signerActiveEnterprise(): Enterprise | undefined {
-    if (this.signerActiveEnterpriseId !== undefined && this.signerEnterprises) {
-      const activeIndex = this.signerEnterprises.findIndex(
-        (enterprise) => enterprise && enterprise.id === this.signerActiveEnterpriseId
-      )
-      return this.signerEnterprises[activeIndex]
-    }
-    return undefined
+    if (enterprises.length !== balance) return undefined
+    return enterprises
   }
 }

--- a/apps/frontend/acquisition-royale-home/src/stores/RootStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/RootStore.ts
@@ -10,9 +10,11 @@ import { AcquireRPCostContractStore } from './AcquireRPCostContractStore'
 import { AcquisitionRoyaleContractStore } from './AcquisitionRoyaleContractStore'
 import { AcquisitionRoyaleRPShopContractStore } from './AcquisitionRoyaleRPShopContractStore'
 import { CompeteV1ContractStore } from './CompeteV1ContractStore'
+import { CompetitionStore } from './CompetitionStore'
 import { ConsumablesContractStore } from './ConsumablesContractStore'
 import { MergeRPCostContractStore } from './MergeRPCostContract'
 import { RunwayPointsContractStore } from './RunwayPointsContractStore'
+import { SignerStore } from './SignerStore'
 import { InternContractStore } from './InternContractStore'
 import { InternStore } from './InternStore'
 import { EnterpriseStore } from './EnterprisesStore'
@@ -30,6 +32,7 @@ export class RootStore extends PRootStore<SupportedContracts> {
   acquisitionRoyaleContractStore: AcquisitionRoyaleContractStore
   acquisitionRoyaleRPShopContractStore: AcquisitionRoyaleRPShopContractStore
   competeV1ContractStore: CompeteV1ContractStore
+  competitionStore: CompetitionStore
   consumablesContractStore: ConsumablesContractStore
   mergeStore: MergeStore
   mergeRPCostContractStore: MergeRPCostContractStore
@@ -43,6 +46,7 @@ export class RootStore extends PRootStore<SupportedContracts> {
   internContractStore: InternContractStore
   internStore: InternStore
   rpShopStore: RpShopStore
+  signerStore: SignerStore
 
   constructor() {
     super({
@@ -62,6 +66,8 @@ export class RootStore extends PRootStore<SupportedContracts> {
     this.acquisitionRoyaleRPShopContractStore = new AcquisitionRoyaleRPShopContractStore(this)
     this.acquireStore = new AcquireStore(this)
     this.consumablesContractStore = new ConsumablesContractStore(this)
+    this.competitionStore = new CompetitionStore(this)
+    this.signerStore = new SignerStore(this)
     this.mergeStore = new MergeStore(this)
     this.mergeRPCostContractStore = new MergeRPCostContractStore(this)
     this.runwayPointsContractStore = new RunwayPointsContractStore(this)

--- a/apps/frontend/acquisition-royale-home/src/stores/SignerStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/SignerStore.ts
@@ -1,0 +1,88 @@
+import { makeAutoObservable, reaction } from 'mobx'
+import { RootStore } from './RootStore'
+import { Enterprise, Enterprises } from '../types/enterprise.types'
+import { transformRawNumber } from '../utils/number-utils'
+
+export class SignerStore {
+  activeEnterpriseId?: number
+  mergeTargetId?: number
+  searchCompetitionQuery?: string
+  slides: number
+  constructor(public root: RootStore) {
+    this.slides = 1
+    makeAutoObservable(this, {}, { autoBind: true })
+
+    this.updateSignerActiveEnterprise()
+  }
+
+  updateSignerActiveEnterprise(): void {
+    reaction(
+      () => this.signerEnterprises,
+      (enterprises) => {
+        if (enterprises === undefined) {
+          if (this.activeEnterpriseId !== undefined) this.clearEnterprises()
+        } else if (this.activeEnterpriseId === undefined) {
+          this.setSignerEnterpriseActiveId(enterprises[0].id)
+        }
+      }
+    )
+  }
+
+  clearEnterprises(): void {
+    this.setSignerEnterpriseActiveId(undefined)
+    this.setMergeTargetId(undefined)
+    this.slides = 1
+  }
+
+  onSignerSlidesChange({ enterpriseId, slides }: { enterpriseId?: number; slides: number }): void {
+    this.setSignerEnterpriseActiveId(enterpriseId)
+    if (slides > this.slides) this.slides = slides
+  }
+
+  setMergeTargetId(id?: number): void {
+    this.mergeTargetId = id
+  }
+
+  setSignerEnterpriseActiveId(id?: number): void {
+    this.activeEnterpriseId = id
+    if (id !== undefined && this.mergeTargetId === id) {
+      this.setMergeTargetId(undefined)
+    }
+  }
+
+  get enterprisesBalance(): number | undefined {
+    const { address } = this.root.web3Store
+    if (address === undefined) return undefined
+    return transformRawNumber(this.root.acquisitionRoyaleContractStore.balanceOf(address))
+  }
+
+  get mergeTargetEnterprise(): Enterprise | undefined {
+    if (this.mergeTargetId !== undefined && this.signerEnterprises) {
+      const mergeIndex = this.signerEnterprises?.findIndex(
+        (enterprise) => enterprise && enterprise.id === this.mergeTargetId
+      )
+      return this.signerEnterprises[mergeIndex]
+    }
+    return undefined
+  }
+
+  get signerActiveEnterprise(): Enterprise | undefined {
+    if (this.activeEnterpriseId !== undefined && this.signerEnterprises) {
+      const activeIndex = this.signerEnterprises.findIndex(
+        (enterprise) => enterprise && enterprise.id === this.activeEnterpriseId
+      )
+      return this.signerEnterprises[activeIndex]
+    }
+    return undefined
+  }
+
+  get signerEnterprises(): Enterprises | undefined {
+    const { address } = this.root.web3Store
+    if (!address) return []
+    return this.root.enterprisesStore.lazyLoad(address, this.slides)
+  }
+
+  get activeIndex(): number | undefined {
+    return this.signerEnterprises?.findIndex(({ id }) => id === this.activeEnterpriseId)
+  }
+}

--- a/apps/frontend/acquisition-royale-home/src/stores/SignerStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/SignerStore.ts
@@ -50,6 +50,10 @@ export class SignerStore {
     }
   }
 
+  get activeIndex(): number | undefined {
+    return this.signerEnterprises?.findIndex(({ id }) => id === this.activeEnterpriseId)
+  }
+
   get enterprisesBalance(): number | undefined {
     const { address } = this.root.web3Store
     if (address === undefined) return undefined
@@ -80,9 +84,5 @@ export class SignerStore {
     const { address } = this.root.web3Store
     if (!address) return []
     return this.root.enterprisesStore.lazyLoad(address, this.slides)
-  }
-
-  get activeIndex(): number | undefined {
-    return this.signerEnterprises?.findIndex(({ id }) => id === this.activeEnterpriseId)
   }
 }

--- a/apps/frontend/acquisition-royale-home/src/types/enterprise.types.ts
+++ b/apps/frontend/acquisition-royale-home/src/types/enterprise.types.ts
@@ -72,4 +72,4 @@ export type UseEnterprise = {
   enterprises: Enterprise[] | undefined
 }
 
-export type Enterprises = (Enterprise | undefined)[]
+export type Enterprises = Enterprise[]


### PR DESCRIPTION
https://www.notion.so/FE-Project-Management-d3878c29e9534234a50f4f8838525bee?p=ca0ef4b10dcf4e10b17a0ff06e6a0246

https://www.notion.so/FE-Project-Management-d3878c29e9534234a50f4f8838525bee?p=963684290dc04fe9b669e1ee71947db7

Changes
- simplified EnterpriseCard (no more glowing, no more clicking)
- refactored EnterprisesStore, moved signer related stuffs to SignerStore (e.g. signerEnterprises, signerActiveEnterprise), and competition related stuffs to CompetitionStore (e.g. competitionEnterprises, competitionActiveEnterprise)
- simplified lazyLoading algorithm: previously it was not using proper "observable approach", values were loaded in autorun, and updated via a property like `signerEnterprises` and `competitionEnterprises`. Now `signerEnterprises` and `competitionEnterprises` are directly the computed value (with values cached nicely on navigate)
- simplified `EnterpriseCarousel` component to work with this main feature of this PR
- simplified `Competition.tsx` and `MyEnterprises.tsx` by moving redundant computation into `EnterpriseCarousel`