### PR TITLE
feat: added PrePO harness to manage deployments for tasks utilities

### DIFF
--- a/apps/smart-contracts/core/harnesses/PrePO.ts
+++ b/apps/smart-contracts/core/harnesses/PrePO.ts
@@ -1,0 +1,144 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { id } from 'ethers/lib/utils'
+import { parseEther } from '@ethersproject/units'
+import { HardhatEthersHelpers } from '@nomiclabs/hardhat-ethers/types'
+import { ContractFactory, ContractTransaction } from 'ethers'
+import { fetchExistingCollateral, fetchExistingPrePOMarketFactory } from '../helpers'
+import { FEE_DENOMINATOR } from '../utils'
+import {
+  MockStrategy,
+  Collateral,
+  PrePOMarket,
+  PrePOMarketFactory,
+  SingleStrategyController,
+  MockBaseToken,
+  CollateralDepositRecord,
+  DepositHook,
+  WithdrawHook,
+} from '../typechain'
+
+export type CreateMarketParams = {
+  tokenNameSuffix: string
+  tokenSymbolSuffix: string
+  governance: string
+  floorLongPrice: BigNumber
+  ceilingLongPrice: BigNumber
+  floorValuation: number
+  ceilingValuation: number
+  mintingFee: number
+  redemptionFee: number
+  expiryTime: number
+}
+
+export const TWO_POW_96 = BigNumber.from(2).pow(96)
+export const TEST_BT_SUPPLY = parseEther('1000000000')
+export const TEST_DEPOSIT_CAP = parseEther('100000')
+export const TEST_MINTING_FEE = 5000
+export const TEST_REDEMPTION_FEE = 5000
+
+export class PrePO {
+  private static _instance: PrePO
+  private initialising!: Promise<PrePO>
+  public ethers!: HardhatEthersHelpers
+  public chainId!: string
+  public accounts!: SignerWithAddress[]
+  public baseToken!: MockBaseToken
+  public mockStrategy!: MockStrategy
+  public collateral!: Collateral
+  public marketFactory!: PrePOMarketFactory
+  public strategyController!: SingleStrategyController
+  public depositHook!: DepositHook
+  public withdrawHook!: WithdrawHook
+  public collateralDepositRecord!: CollateralDepositRecord
+  public marketContractFactory!: ContractFactory
+  public positionContractFactory!: ContractFactory
+  public markets!: {
+    [suffix: string]: {
+      contract: PrePOMarket
+      hash: string
+    }
+  }
+
+  public static get Instance(): PrePO {
+    if (!this._instance) {
+      this._instance = new this()
+    }
+    return this._instance
+  }
+
+  public async init(chainId: string, ethers: HardhatEthersHelpers): Promise<PrePO> {
+    this.chainId = chainId
+    this.ethers = ethers
+    this.accounts = await ethers.getSigners()
+    this.baseToken = await ethers.getContract('MockBaseToken')
+    this.mockStrategy = await ethers.getContract('MockStrategy')
+    this.collateral = await fetchExistingCollateral(chainId, ethers)
+    this.marketFactory = await fetchExistingPrePOMarketFactory(chainId, ethers)
+    this.depositHook = await ethers.getContract('DepositHook')
+    this.withdrawHook = await ethers.getContract('WithdrawHook')
+    this.strategyController = await ethers.getContract('SingleStrategyController')
+    this.collateralDepositRecord = await ethers.getContract('CollateralDepositRecord')
+    this.marketContractFactory = await ethers.getContractFactory('PrePOMarket')
+    this.positionContractFactory = await ethers.getContractFactory('LongShortToken')
+    return this
+  }
+
+  public async createMarket(params: CreateMarketParams): Promise<ContractTransaction> {
+    const tx = await this.marketFactory
+      .connect(this.accounts[0])
+      .createMarket(
+        params.tokenNameSuffix,
+        params.tokenSymbolSuffix,
+        params.governance,
+        this.collateral.address,
+        params.floorLongPrice,
+        params.ceilingLongPrice,
+        params.floorValuation,
+        params.ceilingValuation,
+        params.mintingFee,
+        params.redemptionFee,
+        params.expiryTime
+      )
+    return tx
+  }
+
+  public async getBaseTokenNeededForShares(shares: BigNumber): Promise<BigNumber> {
+    const amountFromShares = await this.collateral.getAmountForShares(shares)
+    return amountFromShares
+      .mul(FEE_DENOMINATOR)
+      .div(FEE_DENOMINATOR.sub(await this.collateral.getMintingFee()))
+      .add(1)
+  }
+}
+
+export async function getCollateralNeededForPosition(
+  market: PrePOMarket,
+  amount: BigNumber
+): Promise<BigNumber> {
+  return amount
+    .mul(FEE_DENOMINATOR)
+    .div(FEE_DENOMINATOR.sub(await market.getMintingFee()))
+    .add(1)
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export async function getMarketAddedEvent(factory: PrePOMarketFactory): Promise<any> {
+  const filter = {
+    address: factory.address,
+    topics: [id('MarketAdded(address,bytes32)')],
+  }
+  const events = await factory.queryFilter(filter, 'latest')
+  return events[0].args as any
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export async function getMintingFee(
+  contract: Collateral | PrePOMarket,
+  amount: BigNumber
+): Promise<BigNumber> {
+  return amount
+    .mul(await contract.getMintingFee())
+    .div(FEE_DENOMINATOR.sub(await contract.getMintingFee()))
+    .add(1)
+}

--- a/apps/smart-contracts/core/package.json
+++ b/apps/smart-contracts/core/package.json
@@ -9,7 +9,7 @@
         "size": "npx hardhat size-contracts",
         "prec": "yarn clean && yarn sl",
         "c": "npx hardhat compile",
-        "l": "yarn prettier --write './deploy/*.ts' './test/**/*.ts' './hardhat.config.ts'",
+        "l": "yarn prettier --write './deploy/*.ts' './test/**/*.ts' './hardhat.config.ts' './harnesses/*.ts' './helpers/*.ts' './utils/*.ts'",
         "pret": "yarn c && yarn l",
         "t": "npx hardhat test",
         "test": "npx hardhat compile && npx hardhat test",

--- a/apps/smart-contracts/core/utils/index.ts
+++ b/apps/smart-contracts/core/utils/index.ts
@@ -1,6 +1,21 @@
 import { parse, stringify } from 'envfile'
-import { Contract } from 'ethers'
+import { BigNumber, Contract } from 'ethers'
 import { readFileSync, writeFileSync } from 'fs'
+
+export const ZERO = BigNumber.from(0)
+export const ONE = BigNumber.from(1)
+export const TWO = BigNumber.from(2)
+export const E18 = BigNumber.from(10).pow(18)
+export const MAX_FEE = BigNumber.from(10000)
+export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
+export const FEE_DENOMINATOR = BigNumber.from(1000000)
+
+export function nowPlusMonths(n: number): number {
+  const d = new Date()
+  d.setMonth(d.getMonth() + n)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime() / 1000
+}
 
 export function recordDeployment(envVarName: string, contract: Contract): void {
   const sourcePath = '.env'


### PR DESCRIPTION
This harness is for tasks and scripts to access existing deployments of a core stack, depending on the chain specified.

The `helpers` file has been modified to add a function to fetch an existing `PrePOMarketFactory`. Previously there was only one to obtain an existing `Collateral` contract. I have separated out most of the logic into a generalized function to avoid repeat code. These functions are needed because `Collateral` and `PrePOMarketFactory` are upgradeable and do not utilize `hardhat-deploy`.

I had to disable `no-explicit-any` linting around the `MarketAdded` event fixture because the `TypedEvent` type returned by the event filter contains `any` within the type. I did not continue to try and figure out a workaround to save time.

The `utils` file has been updated with constants and a simple time function taken from our test `utils` to allow tasks to default to a date if none if specified for a market.