### PR TITLE
fix: prevent searching immuned or owned enterprises

### DIFF
--- a/apps/frontend/acquisition-royale-home/src/stores/CompetitionStore.ts
+++ b/apps/frontend/acquisition-royale-home/src/stores/CompetitionStore.ts
@@ -33,7 +33,11 @@ export class CompetitionStore {
         if (!searchingRandom) return
         if (randomId === undefined) this.generateRandomId()
         if (randomEnterprise && randomEnterprise.burned !== undefined) {
-          if (randomEnterprise.burned) {
+          const { signerEnterprises } = this.root.signerStore
+          const isOwnEnterprise =
+            (signerEnterprises?.findIndex(({ id }) => id === randomEnterprise.id) ?? -1) >= 0
+
+          if (randomEnterprise.burned || randomEnterprise.immune || isOwnEnterprise) {
             this.generateRandomId()
           } else {
             runInAction(() => {


### PR DESCRIPTION
Added filtering for immune or owned enterprises

Currently when ID of owned enterprises is searched, it will show content for no enterprise found. Which is also wrong because ideally we want to show only enterprises the user can acquire.