### PR TITLE
feat: ability to switch non default eth network

### DIFF
--- a/apps/frontend/core-dapp/global.d.ts
+++ b/apps/frontend/core-dapp/global.d.ts
@@ -4,4 +4,7 @@ import { RootStore } from './src/stores/RootStore'
 
 export declare global {
   var rootStore: RootStore
+  var ethereum: {
+    request: (data: { method: string; params: unknown }) => Promise<null>
+  }
 }

--- a/apps/frontend/core-dapp/src/components/NetworkDropdown.tsx
+++ b/apps/frontend/core-dapp/src/components/NetworkDropdown.tsx
@@ -7,6 +7,7 @@ import Dropdown from './Dropdown'
 import Menu, { MenuItem } from './Menu'
 import { useRootStore } from '../context/RootStoreProvider'
 import useResponsive from '../hooks/useResponsive'
+import { addNetworkToMetamask } from '../utils/metamask-utils'
 
 type NetworkRef = {
   iconName: IconName
@@ -106,10 +107,18 @@ const NetworkDropdown: React.FC = () => {
   } = useRootStore()
   const { network: selectedNetwork } = web3Store
 
-  const selectNetowrk = (id: ChainId): void => {
+  const selectNetowrk = async (id: ChainId): Promise<void> => {
     const network = supportedNetworks.find(({ chainId }) => chainId === id)
     if (network) {
-      web3Store.setNetwork(network)
+      const result = await addNetworkToMetamask({
+        chainId: network.chainId,
+        chainName: network.name,
+        rpcUrls: network.rpcUrls,
+        blockExplorerUrls: [network.blockExplorer],
+      })
+      if (result) {
+        web3Store.setNetwork(network)
+      }
     }
   }
 
@@ -134,7 +143,7 @@ const NetworkDropdown: React.FC = () => {
         <StyledMenuItem
           key={network.name}
           disabled={!network.supported}
-          onClick={(): void => selectNetowrk(network.chainId)}
+          onClick={(): Promise<void> => selectNetowrk(network.chainId)}
         >
           <Item network={network} selectedName={selectedNetwork.name} />
         </StyledMenuItem>

--- a/apps/frontend/core-dapp/src/utils/metamask-utils.ts
+++ b/apps/frontend/core-dapp/src/utils/metamask-utils.ts
@@ -1,0 +1,34 @@
+import { ChainId } from '@prepo-io/constants'
+
+type MetamaskNetwork = {
+  chainName: string
+  rpcUrls: string[]
+  blockExplorerUrls: string[]
+  chainId: ChainId
+}
+
+const DEFAULT_NETWORKS = [1, 3, 4, 5, 42]
+
+export const addNetworkToMetamask = async ({
+  chainName,
+  chainId: decChainId,
+  blockExplorerUrls,
+  rpcUrls,
+}: MetamaskNetwork): Promise<boolean> => {
+  if (!window.ethereum || DEFAULT_NETWORKS.includes(decChainId)) {
+    return true
+  }
+  const chainId = `0x${decChainId.toString(16)}`
+  await window.ethereum.request({
+    method: 'wallet_addEthereumChain',
+    params: [
+      {
+        chainName,
+        rpcUrls,
+        chainId,
+        blockExplorerUrls,
+      },
+    ],
+  })
+  return true
+}


### PR DESCRIPTION
to test it
add supported networks in stores-config.ts
supportedNetworks: [NETWORKS.goerli, NETWORKS.arbitrumone, NETWORKS.arbitrumtestnet],
start switching networks with dropdown(you can remove arbitrum networks from metamask, it will asks to add new network and switch after OR switch to selected network if you already have it in Metamask)

https://www.notion.so/eb96722b397d42c9908002ca06af88e3?v=35dcf02f76284d8e8efe0b67f7a04234