### PR TITLE
fix: use fullyear instead of hardcoded year

### DIFF
--- a/apps/frontend/website/src/components/layout/Footer.tsx
+++ b/apps/frontend/website/src/components/layout/Footer.tsx
@@ -181,7 +181,7 @@ export const Footer: FC = () => (
       </div>
       <div className="flex flex-col flex-wrap gap-5 items-center p-5 text-sm text-center sm:py-12 lg:flex-row lg:justify-between xl:px-0">
         <div className="text-sm font-semibold text-secondary sm:text-lg text-opacity-60">
-          &copy; prePO 2021. All rights reserved.
+          &copy; prePO {new Date().getFullYear()}. All rights reserved.
         </div>
         <SocialLinks />
       </div>


### PR DESCRIPTION
https://www.notion.so/Copyright-year-should-be-2022-in-website-footer-7944ab2adb974cacac6cc0727e7ef79b

![Screenshot 2022-05-30 at 11 26 53 AM](https://user-images.githubusercontent.com/81092286/170911800-65fa215a-9049-44b3-b1a0-1c373bbeff60.png)
