### PR TITLE
feat: use numberFormatter for percentages

### DIFF
--- a/apps/frontend/core-dapp/src/components/AdvancedSettingsModal/AdvancedSettingsModal.tsx
+++ b/apps/frontend/core-dapp/src/components/AdvancedSettingsModal/AdvancedSettingsModal.tsx
@@ -11,7 +11,9 @@ import Radio from '../Radio'
 import RadioGroup from '../RadioGroup'
 import { useRootStore } from '../../context/RootStoreProvider'
 import useResponsive from '../../hooks/useResponsive'
-import { formatPercent } from '../../utils/number-utils'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { percent } = numberFormatter
 
 const Wrapper = styled.div``
 
@@ -30,7 +32,7 @@ const TitleWrapper = styled.div`
 const MaxSlippageTitle: React.FC<MaxSlippageTitleProps> = ({ slippage = 0 }) => (
   <TitleWrapper>
     <Title>Max Slippage</Title>
-    <Title>{formatPercent(slippage)}%</Title>
+    <Title>{percent(slippage)}</Title>
   </TitleWrapper>
 )
 

--- a/apps/frontend/core-dapp/src/components/Percent.tsx
+++ b/apps/frontend/core-dapp/src/components/Percent.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import styled, { DefaultTheme } from 'styled-components'
 import { media } from 'prepo-ui'
-import { formatPercent } from '../utils/number-utils'
+import { numberFormatter } from '../utils/numberFormatter'
 
 type StylesProps = {
   fontSize?: keyof DefaultTheme['fontSize']
@@ -44,16 +44,16 @@ const Percent: React.FC<Props> = ({
   percentagePrecision,
   className,
 }) => {
+  const { percent } = numberFormatter
   const [percentageValue, setPercentageValue] = useState<string | undefined>(
-    formatPercent(value, percentagePrecision)
+    percent(value, percentagePrecision)
   )
-  const rawPercentValue = formatPercent(value, percentagePrecision)
+  const rawPercentValue = percent(value, percentagePrecision)
 
   useEffect(() => {
     if (format) {
-      const normalizedValue = `${rawPercentValue}`
       const overrideFormat = format(
-        showPlusSign && value > 0 ? `+${normalizedValue}%` : `${normalizedValue}%`
+        showPlusSign && value > 0 ? `+${rawPercentValue}` : `${rawPercentValue}`
       )
       setPercentageValue(overrideFormat)
     }

--- a/apps/frontend/core-dapp/src/components/Table.tsx
+++ b/apps/frontend/core-dapp/src/components/Table.tsx
@@ -3,9 +3,11 @@ import styled from 'styled-components'
 import { spacingIncrement } from 'prepo-ui'
 import Subtitle from './Subtitle'
 import Percent from './Percent'
-import { formatUsd } from '../utils/number-utils'
 import { PositionType } from '../utils/prepo.types'
 import PositionLabel from '../features/position/PositionLabel'
+import { numberFormatter } from '../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 export type RowData = {
   label: string
@@ -69,7 +71,7 @@ const Table: React.FC<Props> = ({
     if (dataItem?.amount !== undefined) {
       return (
         <>
-          {!dataItem.ignoreFormatAmount ? formatUsd(dataItem.amount, true) : dataItem.amount}{' '}
+          {!dataItem.ignoreFormatAmount ? toUsd(dataItem.amount) : dataItem.amount}{' '}
           {dataItem.percent && (
             <PercentWrapper>
               <Percent

--- a/apps/frontend/core-dapp/src/components/charts/FloatingCard.tsx
+++ b/apps/frontend/core-dapp/src/components/charts/FloatingCard.tsx
@@ -3,7 +3,9 @@ import styled, { CSSProperties } from 'styled-components'
 import { coreDappTheme, spacingIncrement } from 'prepo-ui'
 import { FormatPrice, FormatTime, DetailsProps } from './chart-types'
 import { formatChartTooltipTime } from './utils'
-import { formatUsd } from '../../utils/number-utils'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 const { Z_INDEX } = coreDappTheme
 
@@ -44,7 +46,7 @@ export const FloatingCard = forwardRef<HTMLDivElement, Props>(({ label, style, v
 export const renderFloatingCardWithChartDetails = (
   ref: RefObject<HTMLDivElement>,
   details?: DetailsProps,
-  formatPrice: FormatPrice = formatUsd,
+  formatPrice: FormatPrice = toUsd,
   formatTime: FormatTime = formatChartTooltipTime
 ): ReactElement | null => {
   if (!details) return null

--- a/apps/frontend/core-dapp/src/features/delegate/DelegateCard.tsx
+++ b/apps/frontend/core-dapp/src/features/delegate/DelegateCard.tsx
@@ -5,9 +5,11 @@ import { observer } from 'mobx-react-lite'
 import AddressAvatar, { AvatarDiameter } from './AddressAvatar'
 import { getShortAccount } from '../../utils/account-utils'
 import { noSelect } from '../../styles/noSelect.style'
-import { numberWithCommas } from '../../utils/number-utils'
 import { DelegateEntity } from '../../stores/entities/DelegateEntity'
 import { useRootStore } from '../../context/RootStoreProvider'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { withCommas } = numberFormatter
 
 type Props = {
   delegateEntity: DelegateEntity
@@ -142,9 +144,9 @@ const DelegateCard: React.FC<Props> = ({ delegateEntity }) => {
     delegateStore.setSelectedDelegate(delegateEntity)
   }
 
-  const ppoPowerFormat = numberWithCommas(delegateEntity.delegatorsPower)
-  const delegatorsFormat = numberWithCommas(delegateEntity.delegatorsCount)
-  const votingPowerFormat = numberWithCommas(delegateEntity.ppoPower)
+  const ppoPowerFormat = withCommas(delegateEntity.delegatorsPower)
+  const delegatorsFormat = withCommas(delegateEntity.delegatorsCount)
+  const votingPowerFormat = withCommas(delegateEntity.ppoPower)
   const votingPowerTooltip = `${ppoPowerFormat} from PPO Power + ${delegatorsFormat} from Delegators`
 
   return (

--- a/apps/frontend/core-dapp/src/features/history/HistoryItemDesktop.tsx
+++ b/apps/frontend/core-dapp/src/features/history/HistoryItemDesktop.tsx
@@ -5,10 +5,12 @@ import HistoryEventComponent from './HistoryEvent'
 import { HistoryItem } from './history.types'
 import { getHistoryItemIconTitle, eventTypeRequiresPosition } from './history-utils'
 import HistoryIconTitle from '../../components/MarketIconTitle'
-import { formatUsd } from '../../utils/number-utils'
 import { getFullDateTimeFromSeconds } from '../../utils/date-utils'
 import PositionLabel from '../position/PositionLabel'
 import useResponsive from '../../hooks/useResponsive'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 const Wrapper = styled.div`
   border-bottom: 1px solid ${({ theme }): string => theme.color.accent1};
@@ -73,7 +75,7 @@ const HistoryItemDesktop: React.FC<Props> = ({ historyItem }) => {
         </Col>
         <Col xs={6}>
           <SecondaryText>Value</SecondaryText>
-          <PrimaryText>{formatUsd(historyItem.amount, false)}</PrimaryText>
+          <PrimaryText>{toUsd(historyItem.amount)}</PrimaryText>
         </Col>
         <Col xs={6}>
           <SecondaryText>Transaction Time</SecondaryText>

--- a/apps/frontend/core-dapp/src/features/history/HistoryItemMobile.tsx
+++ b/apps/frontend/core-dapp/src/features/history/HistoryItemMobile.tsx
@@ -5,8 +5,10 @@ import HistoryEventComponent from './HistoryEvent'
 import { HistoryItem } from './history.types'
 import { getHistoryItemIconTitle } from './history-utils'
 import HistoryIconTitle from '../../components/MarketIconTitle'
-import { formatUsd } from '../../utils/number-utils'
 import { getFullDateTimeFromSeconds } from '../../utils/date-utils'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 const Wrapper = styled.div`
   border-bottom: 1px solid ${({ theme }): string => theme.color.primaryAccent};
@@ -59,7 +61,7 @@ const HistoryItemMobile: React.FC<Props> = ({ historyItem }) => {
       </HistoryItemRow>
       <HistoryItemRow>
         <Col xs={8}>
-          <AmountUsd>{formatUsd(historyItem.amount, false)}</AmountUsd>
+          <AmountUsd>{toUsd(historyItem.amount)}</AmountUsd>
         </Col>
         <Col xs={16}>
           <Timestamp>{getFullDateTimeFromSeconds(historyItem.timestamp)}</Timestamp>

--- a/apps/frontend/core-dapp/src/features/market-overview/MarketChart.tsx
+++ b/apps/frontend/core-dapp/src/features/market-overview/MarketChart.tsx
@@ -12,9 +12,11 @@ import useTransformedTVLData from '../../hooks/useTransformedTVLData'
 import useTransformedValuationData from '../../hooks/useTransformedValuationData'
 import useTransformedVolumeData from '../../hooks/useTransformedVolumeData'
 import HistogramChart from '../../components/charts/templates/HistogramChart'
-import { formatPrice } from '../../utils/number-utils'
 import useSelectedMarket from '../../hooks/useSelectedMarket'
 import LoadingLottie from '../../components/lottie-animations/LoadingLottie'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { significantDigits } = numberFormatter
 
 const ChartBox = styled.div`
   background-color: ${({ theme }): string => theme.color.marketChartBackground};
@@ -153,7 +155,7 @@ const MarketChart: React.FC = () => {
       },
       chartTooltipFormatter: {
         formatPrice: (price?: number): string =>
-          price === undefined ? 'N/A' : formatPrice(price, 99999),
+          price === undefined ? 'N/A' : significantDigits(price),
       },
     }
 

--- a/apps/frontend/core-dapp/src/features/market-overview/MarketDataColumn.tsx
+++ b/apps/frontend/core-dapp/src/features/market-overview/MarketDataColumn.tsx
@@ -4,11 +4,11 @@ import { useEffect, useRef, useState } from 'react'
 import FinancialInfoCard from '../../components/FinancialInfoCard'
 import useSelectedMarket from '../../hooks/useSelectedMarket'
 import { getFullDateFromMs, getFullDateShortenMonthFromMs } from '../../utils/date-utils'
-import { formatPercent } from '../../utils/number-utils'
 import { numberFormatter } from '../../utils/numberFormatter'
 import { EstimatedValuation, ExpiryDate, PayoutRange } from '../definitions'
 
 const DATE_BREAKPOINT = 250
+const { percent } = numberFormatter
 
 const MarketDataColumn: React.FC = () => {
   const selectedMarket = useSelectedMarket()
@@ -46,14 +46,14 @@ const MarketDataColumn: React.FC = () => {
 
   const renderPayoutRange = (): React.ReactNode => {
     if (!payoutRange) return null
-    const floorRange = formatPercent(`${payoutRange[0]}`, 0)
-    const ceilingRange = formatPercent(`${payoutRange[1]}`, 0)
+    const floorRange = percent(`${payoutRange[0]}`, 0)
+    const ceilingRange = percent(`${payoutRange[1]}`, 0)
     return (
       <Col xs={24}>
         <FinancialInfoCard
           title="Payout Range"
           tooltip={<PayoutRange />}
-          value={`${floorRange}% - ${ceilingRange}%`}
+          value={`${floorRange} - ${ceilingRange}`}
         />
       </Col>
     )

--- a/apps/frontend/core-dapp/src/features/portfolio/Portfolio.tsx
+++ b/apps/frontend/core-dapp/src/features/portfolio/Portfolio.tsx
@@ -19,7 +19,9 @@ import PositionsAndHistory from './PositionsAndHistory'
 import { makeRepeatedValue } from '../../utils/generic-utils'
 import useResponsive from '../../hooks/useResponsive'
 import { useRootStore } from '../../context/RootStoreProvider'
-import { formatUsd } from '../../utils/number-utils'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 const Box = styled(Col)`
   border: 1px solid ${({ theme }): string => theme.color.neutral8};
@@ -94,7 +96,7 @@ const Portfolio: React.FC = () => {
     if (!connected) return '-'
     if (!isPortfolioVisible) return makeRepeatedValue('*', 9)
     if (portfolioValue === undefined) return <Skeleton width={120} />
-    return `${formatUsd(portfolioValue)}`
+    return `${toUsd(portfolioValue)}`
   }, [connected, isPortfolioVisible, portfolioValue])
 
   const renderPortfolioBreakdown = useMemo(

--- a/apps/frontend/core-dapp/src/features/portfolio/PortfolioBreakdownItem.tsx
+++ b/apps/frontend/core-dapp/src/features/portfolio/PortfolioBreakdownItem.tsx
@@ -6,7 +6,9 @@ import Skeleton from 'react-loading-skeleton'
 import styled from 'styled-components'
 import Percent from '../../components/Percent'
 import { useRootStore } from '../../context/RootStoreProvider'
-import { formatUsd } from '../../utils/number-utils'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 type GrowthProps = {
   amount: number
@@ -46,7 +48,7 @@ const PortfolioBreakdownItem: React.FC<PortfolioBreakdownItemProps> = ({
           <Skeleton height={18} width={70} />
         </SkeletonWrapper>
       )
-    return `${formatUsd(value)}`
+    return `${toUsd(value)}`
   }, [connected, value])
 
   return (

--- a/apps/frontend/core-dapp/src/features/position/PositionItem.tsx
+++ b/apps/frontend/core-dapp/src/features/position/PositionItem.tsx
@@ -7,7 +7,9 @@ import MarketIconTitle from '../../components/MarketIconTitle'
 import Percent from '../../components/Percent'
 import { Position } from '../portfolio/PortfolioStore'
 import { useRootStore } from '../../context/RootStoreProvider'
-import { formatUsd } from '../../utils/number-utils'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 type Props = { position: Required<Position> }
 
@@ -184,7 +186,7 @@ const PositionItem: React.FC<Props> = ({ position }) => {
           <ResponsiveData key={label}>
             <StyledSubtitle tooltip={toolTip}>{label}</StyledSubtitle>
             <ResponsiveDataValue>
-              <p>{formatUsd(amount, true)}&nbsp;</p>
+              <p>{toUsd(amount)}&nbsp;</p>
               {percent !== undefined && (
                 <Percent
                   showPlusSign

--- a/apps/frontend/core-dapp/src/features/trade/EstimateProfitLoss.tsx
+++ b/apps/frontend/core-dapp/src/features/trade/EstimateProfitLoss.tsx
@@ -8,8 +8,11 @@ import { useRootStore } from '../../context/RootStoreProvider'
 import { EstimateYourProfitLoss } from '../definitions'
 import { ExitProfitLoss, SliderSettings } from '../../types/market.types'
 import Percent from '../../components/Percent'
-import { formatUsd, makeAddStep, numFormatter } from '../../utils/number-utils'
+import { makeAddStep, numFormatter } from '../../utils/number-utils'
 import { TWO_DECIMAL_DENOMINATOR, VALUATION_DENOMINATOR } from '../../lib/constants'
+import { numberFormatter } from '../../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 type Props = {
   sliderSettings: SliderSettings
@@ -94,7 +97,7 @@ const EstimateProfitLoss: React.FC<Props> = ({
     return (
       <div>
         If the market resolves at {sliderNumFormatter(exit)}, your {dynamicProfitLossMessage} would
-        be ≈{formatUsd(exitProfitLoss?.expectedProfitLoss)}
+        be ≈{toUsd(exitProfitLoss?.expectedProfitLoss)}
         <ProfitLossPercent
           value={exitProfitLoss?.expectedProfitLossPercentage}
           showPlusSign

--- a/apps/frontend/core-dapp/src/stores/CollateralStore.ts
+++ b/apps/frontend/core-dapp/src/stores/CollateralStore.ts
@@ -10,7 +10,9 @@ import { getContractCall } from './utils/web3-store-utils'
 import { CollateralAbi, CollateralAbi__factory } from '../../generated/typechain'
 import { SupportedContracts } from '../lib/contract.types'
 import { supportedContracts } from '../lib/supported-contracts'
-import { formatUsd } from '../utils/number-utils'
+import { numberFormatter } from '../utils/numberFormatter'
+
+const { toUsd } = numberFormatter
 
 type Deposit = CollateralAbi['functions']['deposit']
 type GetAmountForShares = CollateralAbi['functions']['getAmountForShares']
@@ -157,11 +159,7 @@ export class CollateralStore extends Erc20Store {
   }
 
   get formatSignerBalance(): string {
-    if (this.signerBalance) {
-      return formatUsd(this.signerBalance, true)
-    }
-
-    return '$0'
+    return toUsd(this.signerBalance)
   }
 
   // setters

--- a/apps/frontend/core-dapp/src/utils/__tests__/number-utils.test.ts
+++ b/apps/frontend/core-dapp/src/utils/__tests__/number-utils.test.ts
@@ -1,6 +1,5 @@
 import {
   numFormatter,
-  numberWithCommas,
   formatPercent,
   validateNumber,
   normalizeDecimalPrecision,
@@ -114,17 +113,6 @@ describe('replace large numbers with SI Prefix', () => {
     expect(output5).toBe('789M')
     expect(output6).toBe('78.9M')
     expect(output7).toBe('7.89M')
-  })
-})
-
-describe('numberWithCommas tests', () => {
-  it('should return a number with commas as thousands', () => {
-    const output = numberWithCommas(1234)
-    expect(output).toBe('1,234')
-  })
-  it('should return 0', () => {
-    const output = numberWithCommas(0)
-    expect(output).toBe('0')
   })
 })
 

--- a/apps/frontend/core-dapp/src/utils/__tests__/numberFormatter.test.ts
+++ b/apps/frontend/core-dapp/src/utils/__tests__/numberFormatter.test.ts
@@ -1,0 +1,95 @@
+import { numberFormatter } from '../numberFormatter'
+
+describe('numberFormatter tests', () => {
+  describe('significantDigits using SI Prefix', () => {
+    const { significantDigits } = numberFormatter
+    it('should return 3 significant digits', () => {
+      const output1 = significantDigits(1000000000)
+      const output2 = significantDigits(1230000000)
+      const output3 = significantDigits(12300000000)
+      const output4 = significantDigits(123000000000)
+      const output5 = significantDigits(789000000)
+      const output6 = significantDigits(78900000)
+      const output7 = significantDigits(7890000)
+      expect(output1).toBe('1.00B')
+      expect(output2).toBe('1.23B')
+      expect(output3).toBe('12.3B')
+      expect(output4).toBe('123B')
+      expect(output5).toBe('789M')
+      expect(output6).toBe('78.9M')
+      expect(output7).toBe('7.89M')
+    })
+  })
+
+  describe('rawPercent', () => {
+    const { rawPercent } = numberFormatter
+    it('should return a percentage without the % preffix', () => {
+      const output1 = rawPercent(0.23)
+      const output2 = rawPercent('0.23')
+      const output3 = rawPercent(0.32423123423)
+      expect(output1).toBe('23.0')
+      expect(output2).toBe('23.0')
+      expect(output3).toBe('32.4')
+    })
+
+    it('should return the value with default precision of 1 decimal', () => {
+      const output1 = rawPercent(0.32423123423)
+      const output2 = rawPercent('0.32423123423')
+      expect(output1).toBe('32.4')
+      expect(output2).toBe('32.4')
+    })
+
+    it('should return the value with custom precision', () => {
+      const precision = 2
+      const output1 = rawPercent(0.32423123423, precision)
+      const output2 = rawPercent('0.32423123423', precision)
+      expect(output1).toBe('32.42')
+      expect(output2).toBe('32.42')
+    })
+
+    it('should return undefined', () => {
+      const output1 = rawPercent(NaN)
+      const output2 = rawPercent(1.2)
+      const output3 = rawPercent(-1.2)
+      expect(output1).toBe(undefined)
+      expect(output2).toBe(undefined)
+      expect(output3).toBe(undefined)
+    })
+  })
+
+  describe('percent', () => {
+    const { percent } = numberFormatter
+    it('should return a percentage with the % preffix', () => {
+      const output1 = percent(0.23)
+      const output2 = percent('0.23')
+      const output3 = percent(0.32423123423)
+      expect(output1).toBe('23.0%')
+      expect(output2).toBe('23.0%')
+      expect(output3).toBe('32.4%')
+    })
+
+    it('should return the value with default precision of 1 decimal', () => {
+      const output1 = percent(0.32423123423)
+      const output2 = percent('0.32423123423')
+      expect(output1).toBe('32.4%')
+      expect(output2).toBe('32.4%')
+    })
+
+    it('should return the value with custom precision', () => {
+      const precision = 2
+      const output1 = percent(0.32423123423, precision)
+      const output2 = percent('0.32423123423', precision)
+      expect(output1).toBe('32.42%')
+      expect(output2).toBe('32.42%')
+    })
+
+    it('should return undefined', () => {
+      const output1 = percent(NaN)
+      const output2 = percent(1.2)
+      const output3 = percent(-1.2)
+      expect(output1).toBe(undefined)
+      expect(output2).toBe(undefined)
+      expect(output3).toBe(undefined)
+    })
+  })
+})

--- a/apps/frontend/core-dapp/src/utils/__tests__/numberFormatter.test.ts
+++ b/apps/frontend/core-dapp/src/utils/__tests__/numberFormatter.test.ts
@@ -92,4 +92,42 @@ describe('numberFormatter tests', () => {
       expect(output3).toBe(undefined)
     })
   })
+
+  describe('withCommas', () => {
+    const { withCommas } = numberFormatter
+    it('should return a number with commas as thousands', () => {
+      const output1 = withCommas(1234)
+      const output2 = withCommas(12345678)
+      const output3 = withCommas(12345678912)
+      expect(output1).toBe('1,234')
+      expect(output2).toBe('12,345,678')
+      expect(output3).toBe('12,345,678,912')
+    })
+
+    it('should return 0', () => {
+      const output = withCommas(0)
+      expect(output).toBe('0')
+    })
+  })
+
+  describe('toUsd', () => {
+    const { toUsd } = numberFormatter
+    it('should return a number formatted with USD and currency precision', () => {
+      const output1 = toUsd(1234)
+      const output2 = toUsd(12345678)
+      const output3 = toUsd(12345678912)
+      expect(output1).toBe('$1,234.00')
+      expect(output2).toBe('$12,345,678.00')
+      expect(output3).toBe('$12,345,678,912.00')
+    })
+
+    it('should return $0', () => {
+      const output1 = toUsd(undefined)
+      const output2 = toUsd('')
+      const output3 = toUsd(NaN)
+      expect(output1).toBe('$0.00')
+      expect(output2).toBe('$0.00')
+      expect(output3).toBe('$0.00')
+    })
+  })
 })

--- a/apps/frontend/core-dapp/src/utils/number-utils.ts
+++ b/apps/frontend/core-dapp/src/utils/number-utils.ts
@@ -94,19 +94,15 @@ export const validateNumber = (value: number | string | undefined = 0): number =
   return 0
 }
 
-export const numberWithCommas = (numberValue: number | undefined): string => {
-  if (!numberValue) return '0'
-  return numberValue.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-}
-
 /**
  * Makes sure to avoid getting large string numbers like
  * 14.999999999999999999 when converting from BigNumber to string
  * This will always return the amount of digits that are needed according to our currency precision
  * @returns string
  */
-export const normalizeDecimalPrecision = (numberAsString: string | undefined): string => {
-  if (!numberAsString) return '0'
+export const normalizeDecimalPrecision = (value: string | number | undefined): string => {
+  if (!value || Number.isNaN(value)) return '0'
+  const numberAsString = `${value}`
   const decimalsPrecision = `^-?\\d+(?:\\.\\d{0,${CURRENCY_PRECISION}})?`
   const matchResult = numberAsString.match(decimalsPrecision)
   return matchResult ? matchResult[0] : numberAsString
@@ -118,8 +114,8 @@ export const normalizeDecimalPrecision = (numberAsString: string | undefined): s
  * @param amount - The amount to format
  * @param [decimals=true] - If true, the amount will be formatted with decimals
  */
-export function formatUsd(amount: number | string, decimals = true): string {
-  const normalizeAmount = normalizeDecimalPrecision(`${amount}`)
+export function formatUsd(amount: number | string | undefined, decimals = true): string {
+  const normalizeAmount = normalizeDecimalPrecision(amount)
   const usd = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
@@ -128,11 +124,4 @@ export function formatUsd(amount: number | string, decimals = true): string {
   if (decimals) return usd
 
   return usd.split('.')[0]
-}
-
-export const formatPrice = (num: number, breakpoint: number): string => {
-  if (num > breakpoint) {
-    return `$${numFormatter(num)}`
-  }
-  return formatUsd(num)
 }

--- a/apps/frontend/core-dapp/src/utils/number-utils.ts
+++ b/apps/frontend/core-dapp/src/utils/number-utils.ts
@@ -4,7 +4,8 @@ import { BigNumber } from 'ethers'
 import { formatUnits } from 'ethers/lib/utils'
 import { ERC20_UNITS } from '../lib/constants'
 
-/** It is common to use string type to maintain values with precision. If the output is undefined, this input cannot be converted to percent (e.g. invalid string) */
+/** It is common to use string type to maintain values with precision.
+ * If the output is undefined, this input cannot be converted to percent (e.g. invalid string) */
 export function formatPercent(percent: number | string, precision = 1): string | undefined {
   const transformedPercent = +percent
   if (

--- a/apps/frontend/core-dapp/src/utils/numberFormatter.ts
+++ b/apps/frontend/core-dapp/src/utils/numberFormatter.ts
@@ -1,4 +1,4 @@
-import { formatPercent, numFormatter } from './number-utils'
+import { formatPercent, formatUsd, numFormatter } from './number-utils'
 
 /**
  * Exposes all the possible formats that you will need to apply to numbers across the app
@@ -33,4 +33,24 @@ export const numberFormatter = {
     const formatResult = formatPercent(value, precision)
     return formatResult ? `${formatResult}%` : undefined
   },
+  /**
+   * Will return the value with decimal separator as comma. Example: 1,200,000
+   * @memberof numberFormatter
+   * @method withCommas
+   * @param value - The value that will be formatted.
+   */
+  withCommas: (value: number | undefined): string => {
+    if (!value) return '0'
+    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  },
+
+  /**
+   * Will return the value as USD.
+   * Returns the number with CURRENCY_PRECISION configured on the application
+   * Example: $1,200,000.00
+   * @memberof numberFormatter
+   * @method toUsd
+   * @param value - The value that will be formatted.
+   */
+  toUsd: (value: number | string | undefined): string => formatUsd(value),
 }

--- a/apps/frontend/core-dapp/src/utils/numberFormatter.ts
+++ b/apps/frontend/core-dapp/src/utils/numberFormatter.ts
@@ -1,10 +1,36 @@
-import { numFormatter } from './number-utils'
+import { formatPercent, numFormatter } from './number-utils'
 
 /**
  * Exposes all the possible formats that you will need to apply to numbers across the app
- * @param significantDigits - Will return 3 significant digits. Example: 1.20M
+ * @namespace numberFormatter
  */
 export const numberFormatter = {
+  /**
+   * Will return 3 significant digits. Example: 1.20M
+   * @memberof numberFormatter
+   * @method significantDigits
+   * @param value - The value that will be formatted.
+   */
   significantDigits: (value: number | string): string =>
     numFormatter(value, { significantDigits: 3 }),
+  /**
+   * Will return the value in percentage without the % suffix. Example: 12.3 for 12.3%.
+   * @memberof numberFormatter
+   * @method rawPercent
+   * @param value - The value that will be formatted.
+   * @param precision - Default = 1.
+   */
+  rawPercent: (value: number | string, precision = 1): string | undefined =>
+    formatPercent(value, precision),
+  /**
+   * Will return the value as a percent string. Example: 12.3%. You can send 'precision' as parameter
+   * @memberof numberFormatter
+   * @method percent
+   * @param value - The value that will be formatted.
+   * @param precision - Default = 1.
+   */
+  percent: (value: number | string, precision = 1): string | undefined => {
+    const formatResult = formatPercent(value, precision)
+    return formatResult ? `${formatResult}%` : undefined
+  },
 }


### PR DESCRIPTION
https://www.notion.so/Normalize-only-1-2-util-functions-to-handle-number-formatting-across-the-app-e52b2469c7dd470eaa7fa890e6fda841

## Description
Removes `formatPercentage` from the app. We can now use `numberFormatter.percentage()` or `numberFormatter.rawPercentage()` for those cases