### PR TITLE
fix: percentage label color

### DIFF
--- a/apps/frontend/core-dapp/src/components/Percent.tsx
+++ b/apps/frontend/core-dapp/src/components/Percent.tsx
@@ -3,7 +3,7 @@ import styled, { DefaultTheme } from 'styled-components'
 import { media } from 'prepo-ui'
 import { numberFormatter } from '../utils/numberFormatter'
 
-const { percent } = numberFormatter
+const { percent, rawPercent } = numberFormatter
 
 type StylesProps = {
   fontSize?: keyof DefaultTheme['fontSize']
@@ -49,7 +49,7 @@ const Percent: React.FC<Props> = ({
   const [percentageValue, setPercentageValue] = useState<string | undefined>(
     percent(value, percentagePrecision)
   )
-  const rawPercentValue = percent(value, percentagePrecision)
+  const rawPercentValue = rawPercent(value, percentagePrecision)
 
   useEffect(() => {
     if (format) {

--- a/apps/frontend/core-dapp/src/components/Percent.tsx
+++ b/apps/frontend/core-dapp/src/components/Percent.tsx
@@ -50,15 +50,16 @@ const Percent: React.FC<Props> = ({
     percent(value, percentagePrecision)
   )
   const rawPercentValue = rawPercent(value, percentagePrecision)
+  const percentValue = percent(value, percentagePrecision)
 
   useEffect(() => {
     if (format) {
       const overrideFormat = format(
-        showPlusSign && value > 0 ? `+${rawPercentValue}` : `${rawPercentValue}`
+        showPlusSign && value > 0 ? `+${percentValue}` : `${percentValue}`
       )
       setPercentageValue(overrideFormat)
     }
-  }, [value, format, rawPercentValue, showPlusSign])
+  }, [value, format, percentValue, showPlusSign])
 
   if (rawPercentValue === undefined) {
     return null


### PR DESCRIPTION
https://www.notion.so/Fix-showing-red-percentage-on-Estimated-PnL-slider-label-when-it-s-positive-895d9a2c27874feeba604f6ffca7fffc