### PR TITLE
fix: portfolio breakdown mobile design

### DIFF
--- a/apps/frontend/core-dapp/src/features/portfolio/Portfolio.tsx
+++ b/apps/frontend/core-dapp/src/features/portfolio/Portfolio.tsx
@@ -39,16 +39,6 @@ const BalanceText = styled.p`
     line-height: ${({ theme }): string => theme.fontSize['4xl']};
   `}
 `
-const BlackText = styled.p`
-  color: ${({ theme }): string => theme.color.neutral2};
-  font-size: ${({ theme }): string => theme.fontSize.sm};
-  line-height: ${spacingIncrement(18)};
-  margin: 0;
-  margin-right: ${spacingIncrement(17)};
-  ${media.desktop`
-    font-size: ${({ theme }): string => theme.fontSize.md};
-  `}
-`
 
 const IconWrapper = styled.div`
   cursor: pointer;
@@ -127,7 +117,9 @@ const Portfolio: React.FC = () => {
           <Flex flexDirection="column" alignItems="flex-start" padding={25}>
             <Flex alignItems="flex-start" flexDirection="column" gap={8}>
               <Flex justifyContent="flex-start">
-                <BlackText>Portfolio Value</BlackText>
+                <Typography color="neutral2" variant="text-medium-md" mr={17}>
+                  Portfolio Value
+                </Typography>
                 <IconWrapper onClick={toggleShowPortfolio}>
                   <Icon
                     color="secondary"
@@ -157,7 +149,7 @@ const Portfolio: React.FC = () => {
       {isDesktop && (
         <Col flex={2}>
           <Box>
-            <Typography color="neutral4" variant="text-semiBold-base" pb={8} pl={27} pt={20}>
+            <Typography color="neutral4" variant="text-semiBold-md" pb={8} pl={27} pt={20}>
               Portfolio Breakdown
             </Typography>
             {renderPortfolioBreakdown}

--- a/apps/frontend/core-dapp/src/features/portfolio/PortfolioBreakdownItem.tsx
+++ b/apps/frontend/core-dapp/src/features/portfolio/PortfolioBreakdownItem.tsx
@@ -56,10 +56,10 @@ const PortfolioBreakdownItem: React.FC<PortfolioBreakdownItemProps> = ({
       <Flex>
         <Icon height="21" width="21" name={iconName} />
         <Flex justifyContent="space-between" width="100%">
-          <Typography color="neutral4" variant="text-medium-sm" ml={10}>
+          <Typography color="neutral4" variant="text-medium-md" ml={10}>
             {label}
           </Typography>
-          <Typography color="neutral4" variant="text-medium-sm">
+          <Typography color="neutral4" variant="text-medium-md">
             {renderValue}
           </Typography>
         </Flex>


### PR DESCRIPTION
https://www.notion.so/Portfolio-breakdown-table-is-not-matching-design-on-mobile-7625c1e03ce54a56b530972c5233ec15


## Screenshot mobile
![image](https://user-images.githubusercontent.com/85726992/174605709-62f3ecfd-4ac9-441c-8f03-6d4ec11b6d1a.png)

## Screenshot desktop
Note: the font-size on Portfolio Breakdown has increased on desktop view. This is due to the consistency that the `Typography` component fixes on the responsiveness of our texts. This doesn't really match 1:1 to the design on figma but it's consistent and it looks good.
![image](https://user-images.githubusercontent.com/85726992/174605787-9f7e9982-5edc-460d-bdbc-5fa2037ce093.png)
