### PR TITLE
feat: switching to safeOwnable for token contracts

### DIFF
--- a/apps/smart-contracts/token/contracts/IOUPPO.sol
+++ b/apps/smart-contracts/token/contracts/IOUPPO.sol
@@ -24,6 +24,7 @@ contract IOUPPO is IIOUPPO, ERC20Upgradeable, OwnableUpgradeable, ReentrancyGuar
     ERC20Upgradeable.__ERC20_init("IOU PPO Token", "IOUPPO");
     OwnableUpgradeable.__Ownable_init();
     __ReentrancyGuard_init();
+    // TODO: switch to nominate + accept using SafeOwnableUpgradeable
     _transferOwnership(_governance);
   }
 

--- a/apps/smart-contracts/token/contracts/PPO.sol
+++ b/apps/smart-contracts/token/contracts/PPO.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract PPO is ERC20Upgradeable, OwnableUpgradeable {
   function initialize() public initializer {
+    // TODO: switch to nominate + accept using SafeOwnableUpgradeable
     OwnableUpgradeable.__Ownable_init();
     ERC20Upgradeable.__ERC20_init("prePO Token", "PPO");
     _mint(msg.sender, 1e27); // 1 billion

--- a/apps/smart-contracts/token/contracts/PregenPass.sol
+++ b/apps/smart-contracts/token/contracts/PregenPass.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.7;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "./shared/SafeOwnable.sol";
 
-contract PregenPass is Ownable, ERC721Enumerable {
+contract PregenPass is SafeOwnable, ERC721Enumerable {
   uint256 private _id;
   string private _uri;
 
   /// @dev owner needs to be set as the prePO governance address not the deployer
   constructor(address _owner, string memory _newURI) ERC721("Pregen Pass", "PREGENPASS") {
-    _transferOwnership(_owner);
+    transferOwnership(_owner);
     _uri = _newURI;
   }
 

--- a/apps/smart-contracts/token/contracts/PregenesisPoints.sol
+++ b/apps/smart-contracts/token/contracts/PregenesisPoints.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.7;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "./interfaces/IPregenesisPoints.sol";
+import "./shared/SafeOwnable.sol";
 
-contract PregenesisPoints is IPregenesisPoints, Ownable, ReentrancyGuard, ERC20 {
+contract PregenesisPoints is IPregenesisPoints, SafeOwnable, ReentrancyGuard, ERC20 {
   address private _shop;
   bytes32 private _root;
   mapping(address => bool) private _userToClaim;
@@ -17,8 +17,7 @@ contract PregenesisPoints is IPregenesisPoints, Ownable, ReentrancyGuard, ERC20 
     string memory _name,
     string memory _symbol
   ) ERC20(_name, _symbol) {
-    //TODO: switch to nominate + accept version using `safeOwnable`
-    _transferOwnership(_owner);
+    transferOwnership(_owner);
   }
 
   function setShop(address _newShop) external override onlyOwner {

--- a/apps/smart-contracts/token/contracts/PurchaseHook.sol
+++ b/apps/smart-contracts/token/contracts/PurchaseHook.sol
@@ -3,9 +3,9 @@ pragma solidity =0.8.7;
 
 import "./interfaces/IPurchaseHook.sol";
 import "./interfaces/ITokenShop.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "./shared/SafeOwnable.sol";
 
-contract PurchaseHook is IPurchaseHook, Ownable {
+contract PurchaseHook is IPurchaseHook, SafeOwnable {
   mapping(address => uint256) private _erc721ToMaxPurchasesPerUser;
   mapping(address => mapping(uint256 => uint256)) private _erc1155ToIdToMaxPurchasesPerUser;
   ITokenShop private _tokenShop;

--- a/apps/smart-contracts/token/contracts/TokenShop.sol
+++ b/apps/smart-contracts/token/contracts/TokenShop.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.7;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "./interfaces/ITokenShop.sol";
 import "./interfaces/IPurchaseHook.sol";
+import "./shared/SafeOwnable.sol";
 
-contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
+contract TokenShop is ITokenShop, SafeOwnable, ReentrancyGuard {
   IERC20 private _paymentToken;
   // TODO: Separate pausing logic to a separate Pausable.sol
   bool private _paused;
@@ -24,7 +24,6 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
   }
 
   constructor(address _owner, address _newPaymentToken) {
-    //TODO: switch to nominate + accept version using `safeOwnable`
     transferOwnership(_owner);
     _paymentToken = IERC20(_newPaymentToken);
   }

--- a/apps/smart-contracts/token/contracts/Vesting.sol
+++ b/apps/smart-contracts/token/contracts/Vesting.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.7;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./interfaces/IVesting.sol";
+import "./shared/SafeOwnable.sol";
 
-contract Vesting is IVesting, Ownable, ReentrancyGuard {
+contract Vesting is IVesting, SafeOwnable, ReentrancyGuard {
   using SafeERC20 for IERC20;
 
   bool private _paused;

--- a/apps/smart-contracts/token/contracts/ppostaking/governance/staking/WithdrawalRights.sol
+++ b/apps/smart-contracts/token/contracts/ppostaking/governance/staking/WithdrawalRights.sol
@@ -17,6 +17,7 @@ contract WithdrawalRights is Ownable, ERC721 {
   }
 
   constructor(address _governance) ERC721("Staked PPO Withdrawal Rights", "stkPPO-WR") {
+    // TODO: switch to nominate + accept after pragma is updated.
     _transferOwnership(_governance);
   }
 

--- a/apps/smart-contracts/token/test/PregenPass.test.ts
+++ b/apps/smart-contracts/token/test/PregenPass.test.ts
@@ -15,14 +15,19 @@ describe('PregenPass', () => {
   const URI = 'https://newBaseURI/'
   const URI_2 = 'https://newBaseURI2/'
 
-  const setupPregenPass = async (): Promise<void> => {
+  const deployPregenPass = async (): Promise<void> => {
     ;[deployer, owner, user, user2] = await ethers.getSigners()
     pregenPass = await mockPregenPassFixture(owner.address, URI)
   }
 
+  const setupPregenPass = async (): Promise<void> => {
+    await deployPregenPass()
+    await pregenPass.connect(owner).acceptOwnership()
+  }
+
   describe('constructor', () => {
     before(async () => {
-      await setupPregenPass()
+      await deployPregenPass()
     })
 
     it('sets URI from constructor', async () => {
@@ -37,8 +42,8 @@ describe('PregenPass', () => {
       expect(await pregenPass.symbol()).to.eq('PREGENPASS')
     })
 
-    it('sets owner from constructor', async () => {
-      expect(await pregenPass.owner()).to.eq(owner.address)
+    it('sets nominee from constructor', async () => {
+      expect(await pregenPass.getNominee()).to.eq(owner.address)
     })
   })
 

--- a/apps/smart-contracts/token/test/PregenesisPoints.test.ts
+++ b/apps/smart-contracts/token/test/PregenesisPoints.test.ts
@@ -29,7 +29,7 @@ describe('PregenesisPoints', () => {
   const TOKEN_NAME = `Pregenesis Points`
   const TOKEN_SYMBOL = 'PP'
 
-  const setupPregenesisPoints = async (): Promise<void> => {
+  const deployPregenesisPoints = async (): Promise<void> => {
     ;[deployer, owner, user1, user2, shop] = await ethers.getSigners()
     points = await pregenesisPointsFixture(owner.address, TOKEN_NAME, TOKEN_SYMBOL)
     eligibleNode1 = {
@@ -44,14 +44,19 @@ describe('PregenesisPoints', () => {
     merkleTree = generateAccountAmountMerkleTree(eligibleNodes)
   }
 
+  const setupPregenesisPoints = async (): Promise<void> => {
+    await deployPregenesisPoints()
+    await points.connect(owner).acceptOwnership()
+  }
+
   describe('initial state', () => {
     before(async () => {
-      await setupPregenesisPoints()
+      await deployPregenesisPoints()
     })
 
-    it('sets owner from constructor', async () => {
-      expect(await points.owner()).to.not.eq(deployer.address)
-      expect(await points.owner()).to.eq(owner.address)
+    it('sets nominee from constructor', async () => {
+      expect(await points.getNominee()).to.not.eq(deployer.address)
+      expect(await points.getNominee()).to.eq(owner.address)
     })
 
     it('sets name from constructor', async () => {

--- a/apps/smart-contracts/token/test/TokenShop.test.ts
+++ b/apps/smart-contracts/token/test/TokenShop.test.ts
@@ -25,7 +25,7 @@ describe('TokenShop', () => {
   const tokenIds = [1, 1]
   const amounts = [2, 1]
 
-  const setupTokenShop = async (): Promise<void> => {
+  const deployTokenShop = async (): Promise<void> => {
     ;[deployer, owner, user1] = await ethers.getSigners()
     const mockERC20Recipient = owner.address
     const mockERC20Decimals = 18
@@ -40,6 +40,11 @@ describe('TokenShop', () => {
     tokenShop = await tokenShopFixture(owner.address, paymentToken.address)
   }
 
+  const setupTokenShop = async (): Promise<void> => {
+    await deployTokenShop()
+    await tokenShop.connect(owner).acceptOwnership()
+  }
+
   const setupMockContracts = async (): Promise<void> => {
     const mockERC115Factory = await smock.mock('ERC1155Mintable')
     const mockERC721Factory = await smock.mock('ERC721Mintable')
@@ -49,12 +54,12 @@ describe('TokenShop', () => {
 
   describe('initial state', () => {
     before(async () => {
-      await setupTokenShop()
+      await deployTokenShop()
     })
 
-    it('sets owner from constructor', async () => {
-      expect(await tokenShop.owner()).to.not.eq(deployer.address)
-      expect(await tokenShop.owner()).to.eq(owner.address)
+    it('sets nominee from constructor', async () => {
+      expect(await tokenShop.getNominee()).to.not.eq(deployer.address)
+      expect(await tokenShop.getNominee()).to.eq(owner.address)
     })
 
     it('sets payment token from constructor', async () => {

--- a/apps/smart-contracts/token/test/Vesting.test.ts
+++ b/apps/smart-contracts/token/test/Vesting.test.ts
@@ -36,7 +36,7 @@ describe('Vesting', () => {
   const ONE_ETH = parseEther('1')
   const BLOCK_DURATION_IN_SECONDS = 15
 
-  const setupVesting = async (): Promise<void> => {
+  const deployVesting = async (): Promise<void> => {
     ;[deployer, owner, user1, user2] = await ethers.getSigners()
     vesting = await vestingFixture(owner.address)
     const mockERC20Recipient = owner.address
@@ -51,15 +51,20 @@ describe('Vesting', () => {
     )
   }
 
+  const setupVesting = async (): Promise<void> => {
+    await deployVesting()
+    await vesting.connect(owner).acceptOwnership()
+  }
+
   describe('# initialize', () => {
     before(async () => {
-      await setupVesting()
+      await deployVesting()
     })
 
-    it('sets owner from initialize', async () => {
-      expect(await vesting.owner()).to.not.eq(deployer.address)
+    it('sets nominee from initialize', async () => {
+      expect(await vesting.getNominee()).to.not.eq(deployer.address)
 
-      expect(await vesting.owner()).to.eq(owner.address)
+      expect(await vesting.getNominee()).to.eq(owner.address)
     })
   })
 


### PR DESCRIPTION
* Switching to SafeOwnable version of nominate + accept for all the ownable files of TokenContracts, except OwnableUpgradeable ones (i.e `IOUPPO.sol` and `PPO.sol`).  Added TODO for switching to SafeOwnableUpgradeable in future.
* Also `WithdrawalRights.sol` from ppoStaking need to be switched to safeOwnable, currently it follows `pragma 0.8.6 `which is incompatible with `pragma 0.8.7` of SafeOwnable. Will update it in a separate PR. 