### PR TITLE
feat: adding withdrawERC20 token in tokenShop

### DIFF
--- a/apps/smart-contracts/token/contracts/TokenShop.sol
+++ b/apps/smart-contracts/token/contracts/TokenShop.sol
@@ -84,6 +84,15 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
     }
   }
 
+  function withdrawERC20(address _erc20Token, uint256 _amount)
+    external
+    override
+    onlyOwner
+    nonReentrant
+  {
+    IERC20(_erc20Token).safeTransfer(owner(), _amount);
+  }
+
   function getPrice(address _tokenContract, uint256 _id) external view override returns (uint256) {
     return _contractToIdToPrice[_tokenContract][_id];
   }
@@ -107,15 +116,6 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
     returns (uint256)
   {
     _userToERC721ToPurchaseCount[_user][_tokenContract];
-  }
-
-  function withdrawERC20(address _erc20Token, uint256 _amount)
-    external
-    override
-    onlyOwner
-    nonReentrant
-  {
-    IERC20(_erc20Token).safeTransfer(owner(), _amount);
   }
 
   function onERC1155Received(

--- a/apps/smart-contracts/token/contracts/TokenShop.sol
+++ b/apps/smart-contracts/token/contracts/TokenShop.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.7;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -10,6 +11,8 @@ import "./interfaces/ITokenShop.sol";
 import "./interfaces/IPurchaseHook.sol";
 
 contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
+  using SafeERC20 for IERC20;
+
   IERC20 private _paymentToken;
   // TODO: Separate pausing logic to a separate Pausable.sol
   bool private _paused;
@@ -104,6 +107,15 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
     returns (uint256)
   {
     _userToERC721ToPurchaseCount[_user][_tokenContract];
+  }
+
+  function withdrawERC20(address _erc20Token, uint256 _amount)
+    external
+    override
+    onlyOwner
+    nonReentrant
+  {
+    IERC20(_erc20Token).safeTransfer(owner(), _amount);
   }
 
   function onERC1155Received(

--- a/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
@@ -21,7 +21,7 @@ interface ITokenShop {
     uint256[] memory amounts
   ) external;
 
-  function withdrawERC20(address _erc20Token, uint256 _amount) external;
+  function withdrawERC20(address erc20Token, uint256 amount) external;
 
   function getPrice(address tokenContract, uint256 id) external view returns (uint256);
 

--- a/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
@@ -21,6 +21,8 @@ interface ITokenShop {
     uint256[] memory amounts
   ) external;
 
+  function withdrawERC20(address _erc20Token, uint256 _amount) external;
+
   function getPrice(address tokenContract, uint256 id) external view returns (uint256);
 
   function isPaused() external view returns (bool);
@@ -33,6 +35,4 @@ interface ITokenShop {
     external
     view
     returns (uint256);
-
-  function withdrawERC20(address _erc20Token, uint256 _amount) external;
 }

--- a/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
@@ -33,4 +33,6 @@ interface ITokenShop {
     external
     view
     returns (uint256);
+
+  function withdrawERC20(address _erc20Token, uint256 _amount) external;
 }


### PR DESCRIPTION
* Resubmitting [PR 142](https://github.com/prepo-io/prepo-token-contracts-private/pull/142) from Token-contracts repo for adding a method to withdraw any external ERC20 token deposited into the TokenShop contract.
* This PR was already LGTMd by @ramenforbreakfast 
* The ERC20 token can only be withdrawn by the owner.