### PR TITLE
feat: added methods to withdraw ERC721 and ERC1155 from Token Shop

### DIFF
--- a/apps/smart-contracts/token/contracts/TokenShop.sol
+++ b/apps/smart-contracts/token/contracts/TokenShop.sol
@@ -118,6 +118,23 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
     IERC20(_erc20Token).safeTransfer(owner(), _amount);
   }
 
+  function withdrawERC721(address _erc721Token, uint256 _id)
+    external
+    override
+    onlyOwner
+    nonReentrant
+  {
+    IERC721(_erc721Token).safeTransferFrom(address(this), owner(), _id);
+  }
+
+  function withdrawERC1155(
+    address _erc1155Token,
+    uint256 _id,
+    uint256 _amount
+  ) external override onlyOwner nonReentrant {
+    IERC1155(_erc1155Token).safeTransferFrom(address(this), owner(), _id, _amount, "");
+  }
+
   function onERC1155Received(
     address,
     address,

--- a/apps/smart-contracts/token/contracts/TokenShop.sol
+++ b/apps/smart-contracts/token/contracts/TokenShop.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.7;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -10,6 +11,8 @@ import "./interfaces/ITokenShop.sol";
 import "./interfaces/IPurchaseHook.sol";
 
 contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
+  using SafeERC20 for IERC20;
+
   IERC20 private _paymentToken;
   // TODO: Separate pausing logic to a separate Pausable.sol
   bool private _paused;
@@ -104,6 +107,15 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
     returns (uint256)
   {
     _userToERC721ToPurchaseCount[_user][_tokenContract];
+  }
+
+  function withdrawERC20(address _erc20Token, uint256 _amount)
+    external
+    override
+    onlyOwner
+    nonReentrant
+  {
+    IERC20(_erc20Token).safeTransfer(owner(), _amount);
   }
 
   function onERC1155Received(

--- a/apps/smart-contracts/token/contracts/TokenShop.sol
+++ b/apps/smart-contracts/token/contracts/TokenShop.sol
@@ -93,6 +93,23 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
     IERC20(_erc20Token).safeTransfer(owner(), _amount);
   }
 
+  function withdrawERC721(address _erc721Token, uint256 _id)
+    external
+    override
+    onlyOwner
+    nonReentrant
+  {
+    IERC721(_erc721Token).safeTransferFrom(address(this), owner(), _id);
+  }
+
+  function withdrawERC1155(
+    address _erc1155Token,
+    uint256 _id,
+    uint256 _amount
+  ) external override onlyOwner nonReentrant {
+    IERC1155(_erc1155Token).safeTransferFrom(address(this), owner(), _id, _amount, "");
+  }
+
   function getPrice(address _tokenContract, uint256 _id) external view override returns (uint256) {
     return _contractToIdToPrice[_tokenContract][_id];
   }
@@ -116,32 +133,6 @@ contract TokenShop is ITokenShop, Ownable, ReentrancyGuard {
     returns (uint256)
   {
     _userToERC721ToPurchaseCount[_user][_tokenContract];
-  }
-
-  function withdrawERC20(address _erc20Token, uint256 _amount)
-    external
-    override
-    onlyOwner
-    nonReentrant
-  {
-    IERC20(_erc20Token).safeTransfer(owner(), _amount);
-  }
-
-  function withdrawERC721(address _erc721Token, uint256 _id)
-    external
-    override
-    onlyOwner
-    nonReentrant
-  {
-    IERC721(_erc721Token).safeTransferFrom(address(this), owner(), _id);
-  }
-
-  function withdrawERC1155(
-    address _erc1155Token,
-    uint256 _id,
-    uint256 _amount
-  ) external override onlyOwner nonReentrant {
-    IERC1155(_erc1155Token).safeTransferFrom(address(this), owner(), _id, _amount, "");
   }
 
   function onERC1155Received(

--- a/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
@@ -23,6 +23,14 @@ interface ITokenShop {
 
   function withdrawERC20(address erc20Token, uint256 amount) external;
 
+  function withdrawERC721(address erc721Token, uint256 id) external;
+
+  function withdrawERC1155(
+    address erc1155Token,
+    uint256 id,
+    uint256 amount
+  ) external;
+
   function getPrice(address tokenContract, uint256 id) external view returns (uint256);
 
   function isPaused() external view returns (bool);
@@ -35,14 +43,4 @@ interface ITokenShop {
     external
     view
     returns (uint256);
-
-  function withdrawERC20(address _erc20Token, uint256 _amount) external;
-
-  function withdrawERC721(address erc721Token, uint256 id) external;
-
-  function withdrawERC1155(
-    address erc1155Token,
-    uint256 id,
-    uint256 _amount
-  ) external;
 }

--- a/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
@@ -35,4 +35,12 @@ interface ITokenShop {
     returns (uint256);
 
   function withdrawERC20(address _erc20Token, uint256 _amount) external;
+
+  function withdrawERC721(address erc721Token, uint256 id) external;
+
+  function withdrawERC1155(
+    address erc1155Token,
+    uint256 id,
+    uint256 _amount
+  ) external;
 }

--- a/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
@@ -33,4 +33,6 @@ interface ITokenShop {
     external
     view
     returns (uint256);
+
+  function withdrawERC20(address _erc20Token, uint256 _amount) external;
 }

--- a/apps/smart-contracts/token/test/TokenShop.test.ts
+++ b/apps/smart-contracts/token/test/TokenShop.test.ts
@@ -569,6 +569,102 @@ describe('TokenShop', () => {
       expect(await externalERC20Token.balanceOf(tokenShop.address)).to.be.eq(1)
     })
   })
+
+  describe('# withdrawERC721', () => {
+    const erc721Id = 1
+    beforeEach(async () => {
+      await setupTokenShop()
+      await setupMockContracts()
+      await mockERC721.mint(tokenShop.address, erc721Id)
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await tokenShop.owner()).to.not.eq(user1.address)
+
+      await expect(
+        tokenShop.connect(user1).withdrawERC721(mockERC721.address, erc721Id)
+      ).revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('reverts if token id not owned by token shop', async () => {
+      await mockERC721.mint(user1.address, 2)
+      mockERC721.ownerOf.whenCalledWith(2).returns(user1.address)
+
+      await expect(tokenShop.connect(owner).withdrawERC721(mockERC721.address, 2)).revertedWith(
+        'ERC721: transfer caller is not owner nor approved'
+      )
+    })
+
+    it('transfers if token id owned by token shop', async () => {
+      mockERC721.ownerOf.whenCalledWith(erc721Id).returns(tokenShop.address)
+      const tokenShop721BalanceBefore = await mockERC721.balanceOf(tokenShop.address)
+      const ownerERC721BalanceBefore = await mockERC721.balanceOf(owner.address)
+
+      await tokenShop.connect(owner).withdrawERC721(mockERC721.address, erc721Id)
+
+      expect(await mockERC721.balanceOf(owner.address)).to.be.equal(ownerERC721BalanceBefore.add(1))
+      expect(await mockERC721.balanceOf(tokenShop.address)).to.be.equal(
+        tokenShop721BalanceBefore.sub(1)
+      )
+    })
+  })
+
+  describe('# withdrawERC1155', () => {
+    const erc1155Id = 1
+    const erc1155Amount = 10
+    beforeEach(async () => {
+      await setupTokenShop()
+      await setupMockContracts()
+      await mockERC1155.mint(tokenShop.address, erc1155Id, erc1155Amount)
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await tokenShop.owner()).to.not.eq(user1.address)
+
+      await expect(
+        tokenShop.connect(user1).withdrawERC1155(mockERC1155.address, erc1155Id, erc1155Amount)
+      ).revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('reverts if amount to withdraw > balance', async () => {
+      const tokenShopERC1155Balance = await mockERC1155.balanceOf(tokenShop.address, erc1155Id)
+
+      await expect(
+        tokenShop
+          .connect(owner)
+          .withdrawERC1155(mockERC1155.address, 2, tokenShopERC1155Balance.add(1))
+      ).revertedWith('ERC1155: insufficient balance for transfer')
+    })
+
+    it('transfers if amount to withdraw = balance', async () => {
+      const tokenShop1155BalanceBefore = await mockERC1155.balanceOf(tokenShop.address, erc1155Id)
+      const ownerERC1155BalanceBefore = await mockERC1155.balanceOf(owner.address, erc1155Id)
+
+      await tokenShop
+        .connect(owner)
+        .withdrawERC1155(mockERC1155.address, erc1155Id, tokenShop1155BalanceBefore)
+
+      expect(await mockERC1155.balanceOf(owner.address, erc1155Id)).to.be.equal(
+        ownerERC1155BalanceBefore.add(tokenShop1155BalanceBefore)
+      )
+      expect(await mockERC1155.balanceOf(tokenShop.address, erc1155Id)).to.be.equal(ZERO)
+    })
+
+    it('transfers if amount to withdraw < balance', async () => {
+      const tokenShop1155BalanceBefore = await mockERC1155.balanceOf(tokenShop.address, erc1155Id)
+      const ownerERC1155BalanceBefore = await mockERC1155.balanceOf(owner.address, erc1155Id)
+
+      await tokenShop
+        .connect(owner)
+        .withdrawERC1155(mockERC1155.address, erc1155Id, tokenShop1155BalanceBefore.sub(1))
+
+      expect(await mockERC1155.balanceOf(owner.address, erc1155Id)).to.be.equal(
+        ownerERC1155BalanceBefore.add(tokenShop1155BalanceBefore.sub(1))
+      )
+      expect(await mockERC1155.balanceOf(tokenShop.address, erc1155Id)).to.be.equal(1)
+    })
+  })
+
   describe('# onERC1155Received', () => {
     beforeEach(async () => {
       await setupTokenShop()

--- a/apps/smart-contracts/token/test/TokenShop.test.ts
+++ b/apps/smart-contracts/token/test/TokenShop.test.ts
@@ -632,7 +632,7 @@ describe('TokenShop', () => {
       await expect(
         tokenShop
           .connect(owner)
-          .withdrawERC1155(mockERC1155.address, 2, tokenShopERC1155Balance.add(1))
+          .withdrawERC1155(mockERC1155.address, erc1155Id, tokenShopERC1155Balance.add(1))
       ).revertedWith('ERC1155: insufficient balance for transfer')
     })
 


### PR DESCRIPTION
* Resubmitting [PR 143](https://github.com/prepo-io/prepo-token-contracts-private/pull/143) from Token-contracts repo for adding a method to withdraw any external ERC721 or ERC1155 token deposited into the TokenShop contract.
* This PR was already LGTMd by @ramenforbreakfast 
* The ERC721 and ERC1155 token can only be withdrawn by the owner.