### PR TITLE
fix: import from constants instead of package

### DIFF
--- a/apps/subgraphs/core-dapp/src/utils/transactions.ts
+++ b/apps/subgraphs/core-dapp/src/utils/transactions.ts
@@ -1,5 +1,4 @@
 import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
-import { ZERO_ADDRESS } from 'prepo-constants'
 import {
   ACTIONS_RECEIVE,
   ACTIONS_SEND,
@@ -7,6 +6,7 @@ import {
   EVENTS_TRANSFER,
   HistoricalEventTypes,
   ONE_BI,
+  ZERO_ADDRESS,
 } from './constants'
 import { CollateralToken, HistoricalEvent, Pool, Transaction } from '../generated/types/schema'
 


### PR DESCRIPTION
Importing ZERO_ADDRESS from 'prepo-constants' package is causing build to fail. I think this is because subgraphs build with AssemblyScript and AssemblyScript doesn't understand our javascript packages local linking?

![Screenshot 2022-07-02 at 5 42 38 PM](https://user-images.githubusercontent.com/81092286/176995300-f570777c-a2ad-4f8b-820d-f9ef5fce03b0.png)
