### PR TITLE
feat: adding interfaces for PPO and TransferHook

### DIFF
--- a/apps/smart-contracts/token/contracts/interfaces/IPPO.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IPPO.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+import "./ITransferHook.sol";
+
+//TODO: add all natspecs at the end
+interface IPPO {
+    function setTransferHook(ITransferHook newTransferHook) external;
+
+    function mint(uint256 amount) external;
+
+    function burn(uint256 amount) external;
+
+    function burnFrom(address account, uint256 amount) external;
+}

--- a/apps/smart-contracts/token/contracts/interfaces/IPPO.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IPPO.sol
@@ -5,11 +5,11 @@ import "./ITransferHook.sol";
 
 //TODO: add all natspecs at the end
 interface IPPO {
-    function setTransferHook(ITransferHook newTransferHook) external;
+  function setTransferHook(ITransferHook newTransferHook) external;
 
-    function mint(uint256 amount) external;
+  function mint(uint256 amount) external;
 
-    function burn(uint256 amount) external;
+  function burn(uint256 amount) external;
 
-    function burnFrom(address account, uint256 amount) external;
+  function burnFrom(address account, uint256 amount) external;
 }

--- a/apps/smart-contracts/token/contracts/interfaces/ITransferHook.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITransferHook.sol
@@ -3,5 +3,9 @@ pragma solidity =0.8.7;
 
 //TODO: add all natspecs at the end
 interface ITransferHook {
-    function hook(address from, address to, uint256 amount) external;
+  function hook(
+    address from,
+    address to,
+    uint256 amount
+  ) external;
 }

--- a/apps/smart-contracts/token/contracts/interfaces/ITransferHook.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITransferHook.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+//TODO: add all natspecs at the end
+interface ITransferHook {
+    function hook(address from, address to, uint256 amount) external;
+}


### PR DESCRIPTION
* Adding `IPPO` and `ITransferHook` interfaces.
* Did not add `setGovernance` method as we will be using `SafeOwnable` and can just make Governance as the Owner.
* The `ITransferHook` is to be used for restricting/un-restricting of transfers.