### PR TITLE
feat: adding interface for allow list for ppo contract

### DIFF
--- a/apps/smart-contracts/token/contracts/interfaces/IAllowList.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IAllowList.sol
@@ -3,15 +3,11 @@ pragma solidity =0.8.7;
 
 //TODO: add all natspecs at the end
 interface IAllowlist {
-  function allowDestinations(address[] memory accounts) external;
+  function setDestinations(address[] calldata destinations, bool[] calldata allowed) external;
 
-  function removeDestinations(address[] memory accounts) external;
+  function resetDestinations(address[] calldata allowedDestinations) external;
 
-  function resetDestinations() external;
+  function setSources(address[] calldata sources, bool[] calldata allowed) external;
 
-  function allowSources(address[] memory accounts) external;
-
-  function removeSources(address[] memory accounts) external;
-
-  function resetSources() external;
+  function resetSources(address[] calldata allowedSources) external;
 }

--- a/apps/smart-contracts/token/contracts/interfaces/IAllowList.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IAllowList.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+//TODO: add all natspecs at the end
+interface IAllowlist {
+  function allowDestinations(address[] memory accounts) external;
+
+  function removeDestinations(address[] memory accounts) external;
+
+  function resetDestinations() external;
+
+  function allowSources(address[] memory accounts) external;
+
+  function removeSources(address[] memory accounts) external;
+
+  function resetSources() external;
+}


### PR DESCRIPTION
* Adding `IAllowlist` interface.
* This contract will have the functionality to add and remove the list of addresses to allowed sources and destinations.
* Also, `resetDestination` and `resetSources` will follow a logic similar to the one implemented in one of the core dapp [contracts](https://github.com/prepo-io/prepo-monorepo/blob/fae573c0bf17b36628ce0fc5e0cf21f4b594659d/apps/smart-contracts/core/contracts/AccountAccessController.sol#L21).