### PR TITLE
feat: adding interface for block list for ppo contract

### DIFF
--- a/apps/smart-contracts/token/contracts/interfaces/IBlockList.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IBlockList.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+//TODO: add all natspecs at the end
+interface IBlocklist {
+  function blockAccounts(address[] memory accounts) external;
+
+  function removeAccounts(address[] memory accounts) external;
+
+  function reset() external;
+}

--- a/apps/smart-contracts/token/contracts/interfaces/IBlockList.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IBlockList.sol
@@ -3,9 +3,7 @@ pragma solidity =0.8.7;
 
 //TODO: add all natspecs at the end
 interface IBlocklist {
-  function blockAccounts(address[] memory accounts) external;
+  function set(address[] calldata accounts, bool[] calldata blocked) external;
 
-  function removeAccounts(address[] memory accounts) external;
-
-  function reset() external;
+  function reset(address[] calldata blockedAccounts) external;
 }


### PR DESCRIPTION
* Adding `IBlockList` interface.
* This contract will provide the functionality to block and unblock accounts from transferring PPO.
* Also, `reset()` will follow a logic similar to the one implemented in one of the core dapp [contract](https://github.com/prepo-io/prepo-monorepo/blob/fae573c0bf17b36628ce0fc5e0cf21f4b594659d/apps/smart-contracts/core/contracts/AccountAccessController.sol#L21).