### PR TITLE
fix: make SafeOwnableUpgradeable abstract to conform to upgradeable contract convention

### DIFF
--- a/packages/prepo-shared-contracts/contracts/SafeOwnableUpgradeable.sol
+++ b/packages/prepo-shared-contracts/contracts/SafeOwnableUpgradeable.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.7;
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./interfaces/ISafeOwnable.sol";
 
-abstract contract SafeOwnableUpgradeable is ISafeOwnable, OwnableUpgradeable {
+contract SafeOwnableUpgradeable is ISafeOwnable, OwnableUpgradeable {
   address private _nominee;
 
   modifier onlyNominee() {

--- a/packages/prepo-shared-contracts/contracts/SafeOwnableUpgradeable.sol
+++ b/packages/prepo-shared-contracts/contracts/SafeOwnableUpgradeable.sol
@@ -4,16 +4,12 @@ pragma solidity =0.8.7;
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./interfaces/ISafeOwnable.sol";
 
-contract SafeOwnableUpgradeable is ISafeOwnable, OwnableUpgradeable {
+abstract contract SafeOwnableUpgradeable is ISafeOwnable, OwnableUpgradeable {
   address private _nominee;
 
   modifier onlyNominee() {
     require(_msgSender() == _nominee, "SafeOwnable: sender must be nominee");
     _;
-  }
-
-  function initialize() public initializer {
-    __Ownable_init_unchained();
   }
 
   function transferOwnership(address _nominee)

--- a/packages/prepo-shared-contracts/contracts/mock/DeployableSafeOwnableUpgradeable.sol
+++ b/packages/prepo-shared-contracts/contracts/mock/DeployableSafeOwnableUpgradeable.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+import "../SafeOwnableUpgradeable.sol";
+
+contract DeployableSafeOwnableUpgradeable is SafeOwnableUpgradeable {
+  function initialize() public initializer {
+    __Ownable_init();
+  }
+}

--- a/packages/prepo-shared-contracts/test/SafeOwnableUpgradeable.test.ts
+++ b/packages/prepo-shared-contracts/test/SafeOwnableUpgradeable.test.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { ZERO_ADDRESS } from 'prepo-constants'
-import { safeOwnableUpgradeableFixture } from './fixtures/SafeOwnableUpgradeableFixture'
-import { SafeOwnableUpgradeable } from '../types/generated'
+import { deployableSafeOwnableUpgradeableFixture } from './fixtures/DeployableSafeOwnableUpgradeableFixture'
+import { DeployableSafeOwnableUpgradeable } from '../types/generated'
 
 describe('SafeOwnableUpgradeable', () => {
   let deployer: SignerWithAddress
@@ -11,12 +11,12 @@ describe('SafeOwnableUpgradeable', () => {
   let user1: SignerWithAddress
   let user2: SignerWithAddress
   let nominee: SignerWithAddress
-  let safeOwnable: SafeOwnableUpgradeable
+  let safeOwnable: DeployableSafeOwnableUpgradeable
 
   const setupSafeOwnableUpgradeable = async (): Promise<void> => {
     ;[deployer, user1, user2] = await ethers.getSigners()
     owner = deployer
-    safeOwnable = await safeOwnableUpgradeableFixture()
+    safeOwnable = await deployableSafeOwnableUpgradeableFixture()
   }
 
   describe('initial state', () => {

--- a/packages/prepo-shared-contracts/test/fixtures/DeployableSafeOwnableUpgradeableFixture.ts
+++ b/packages/prepo-shared-contracts/test/fixtures/DeployableSafeOwnableUpgradeableFixture.ts
@@ -1,0 +1,7 @@
+import { ethers, upgrades } from 'hardhat'
+import { DeployableSafeOwnableUpgradeable } from '../../types/generated'
+
+export async function deployableSafeOwnableUpgradeableFixture(): Promise<DeployableSafeOwnableUpgradeable> {
+  const Factory = await ethers.getContractFactory('DeployableSafeOwnableUpgradeable')
+  return (await upgrades.deployProxy(Factory)) as DeployableSafeOwnableUpgradeable
+}

--- a/packages/prepo-shared-contracts/test/fixtures/SafeOwnableUpgradeableFixture.ts
+++ b/packages/prepo-shared-contracts/test/fixtures/SafeOwnableUpgradeableFixture.ts
@@ -1,7 +1,0 @@
-import { ethers, upgrades } from 'hardhat'
-import { SafeOwnableUpgradeable } from '../../types/generated'
-
-export async function safeOwnableUpgradeableFixture(): Promise<SafeOwnableUpgradeable> {
-  const Factory = await ethers.getContractFactory('SafeOwnableUpgradeable')
-  return (await upgrades.deployProxy(Factory)) as SafeOwnableUpgradeable
-}


### PR DESCRIPTION
So, while I originally wrote `SafeOwnableUpgradeable` to conform to the convention of `SafeOwnable`, where the contract is not `abstract`, and thus can be delployed without a wrapper contract, there are minor problems that this introduces that I don't think are worth designing around just because we don't want mock or wrapper contracts.

How OpenZeppelin designs upgradeable contracts is that they are not to be initialized at all via the constructor, and are to be initialized afterwards in using a special kind of `initializer` function. `initializer` functions may only be called once, so you can't embed a parent `initializer` function call into your own `initializer` call (it works similar to `ReentrancyGuard`, you can't call a `nonReentrant` function within a `nonReentrant` function because the flag is already set). For example, in `PPO.sol`, to initialize it, we'd call its `initializer` function, but it wouldn't be able to call `SafeOwnableUpgradeable.sol`'s `initializer` function. 

These contracts were never meant to be deployed on their own, but inherited as a module, which is why they are abstract. 

The way around this is we'd have two initialization functions in `SafeOwnableUpgradeable`, one that is an `initializer` for deploying on its own, really only for testing purposes, and one that is just a normal `internal` function that an inheriting contract like `PPO.sol` can call in its own `initializer`. 

I decided to make the call and just make it `abstract` in the mean time for Nilay to continue working, thus we now require a `DeployableSafeOwnableUpgradable.sol` for testing purposes.

If you still feel strongly about this @XavierEkkel, we could add two different initialization functions into `SafeOwnableUpgradeable` so that we don't need a mock to instantiate it for testing. But I don't believe this is the right course of action.