### PR TITLE
feat: initialized blocklist and base state

### DIFF
--- a/apps/smart-contracts/token/contracts/Blocklist.sol
+++ b/apps/smart-contracts/token/contracts/Blocklist.sol
@@ -5,9 +5,26 @@ import "./interfaces/IBlocklist.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 contract Blocklist is IBlocklist, SafeOwnable {
-  constructor(address _nominatedOwner) {}
+  uint256 private _blockedAccountsIndex;
+  mapping(uint256 => mapping(address => bool)) private _blockedAccounts;
 
-  function set(address[] calldata _accounts, bool[] calldata _blocked) external override onlyOwner {}
+  constructor(address _nominatedOwner) {
+    transferOwnership(_nominatedOwner);
+  }
 
-  function reset(address[] calldata _blockedAccounts) external override onlyOwner {}
+  function set(address[] calldata _accounts, bool[] calldata _blocked)
+    external
+    override
+    onlyOwner
+  {}
+
+  function reset(address[] calldata _newBlockedAccounts) external override onlyOwner {}
+
+  function isAccountBlocked(address _account) external view override returns (bool) {
+    return _blockedAccounts[_blockedAccountsIndex][_account];
+  }
+
+  function getBlockedAllountsIndex() external view override returns (uint256) {
+    return _blockedAccountsIndex;
+  }
 }

--- a/apps/smart-contracts/token/contracts/Blocklist.sol
+++ b/apps/smart-contracts/token/contracts/Blocklist.sol
@@ -5,8 +5,8 @@ import "./interfaces/IBlocklist.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 contract Blocklist is IBlocklist, SafeOwnable {
-  uint256 private _blockedAccountsIndex;
-  mapping(uint256 => mapping(address => bool)) private _blockedAccounts;
+  uint256 private _resetIndex;
+  mapping(uint256 => mapping(address => bool)) private _resetIndexToAccountToBlocked;
 
   constructor(address _nominatedOwner) {
     transferOwnership(_nominatedOwner);
@@ -18,13 +18,9 @@ contract Blocklist is IBlocklist, SafeOwnable {
     onlyOwner
   {}
 
-  function reset(address[] calldata _newBlockedAccounts) external override onlyOwner {}
+  function reset(address[] calldata _accountsToBlock) external override onlyOwner {}
 
-  function isAccountBlocked(address _account) external view override returns (bool) {
-    return _blockedAccounts[_blockedAccountsIndex][_account];
-  }
-
-  function getBlockedAllountsIndex() external view override returns (uint256) {
-    return _blockedAccountsIndex;
+  function isBlocked(address _account) external view override returns (bool) {
+    return _resetIndexToAccountToBlocked[_resetIndex][_account];
   }
 }

--- a/apps/smart-contracts/token/contracts/interfaces/IBlocklist.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IBlocklist.sol
@@ -5,9 +5,7 @@ pragma solidity =0.8.7;
 interface IBlocklist {
   function set(address[] calldata accounts, bool[] calldata blocked) external;
 
-  function reset(address[] calldata blockedAccounts) external;
+  function reset(address[] calldata accountsToBlock) external;
 
-  function isAccountBlocked(address account) external view returns (bool);
-
-  function getBlockedAllountsIndex() external view returns (uint256);
+  function isBlocked(address account) external view returns (bool);
 }

--- a/apps/smart-contracts/token/contracts/interfaces/IBlocklist.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IBlocklist.sol
@@ -6,4 +6,8 @@ interface IBlocklist {
   function set(address[] calldata accounts, bool[] calldata blocked) external;
 
   function reset(address[] calldata blockedAccounts) external;
+
+  function isAccountBlocked(address account) external view returns (bool);
+
+  function getBlockedAllountsIndex() external view returns (uint256);
 }

--- a/apps/smart-contracts/token/test/Blocklist.test.ts
+++ b/apps/smart-contracts/token/test/Blocklist.test.ts
@@ -1,5 +1,41 @@
 import { expect } from 'chai'
 import { blocklistFixture } from './fixtures/BlocklistFixtures'
 import { Blocklist } from '../types/generated'
+import { ethers } from 'hardhat'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-describe('=> Blocklist', () => {})
+describe('=> Blocklist', () => {
+  let deployer: SignerWithAddress
+  let owner: SignerWithAddress
+  let user1: SignerWithAddress
+  let blocklist: Blocklist
+
+  const deployBlocklist = async (): Promise<void> => {
+    ;[deployer, owner, user1] = await ethers.getSigners()
+    blocklist = await blocklistFixture(owner.address)
+  }
+
+  const setupBlocklist = async (): Promise<void> => {
+    await deployBlocklist()
+    await blocklist.connect(owner).acceptOwnership()
+  }
+
+  describe('initial state', () => {
+    beforeEach(async () => {
+      await deployBlocklist()
+    })
+
+    it('sets nominee from initialize', async () => {
+      expect(await blocklist.getNominee()).to.not.eq(deployer.address)
+      expect(await blocklist.getNominee()).to.eq(owner.address)
+    })
+
+    it('sets owner to deployer', async () => {
+      expect(await blocklist.owner()).to.eq(deployer.address)
+    })
+
+    it('sets blocked accounts index to zero', async () => {
+      expect(await blocklist.getBlockedAllountsIndex()).to.eq(0)
+    })
+  })
+})

--- a/apps/smart-contracts/token/test/Blocklist.test.ts
+++ b/apps/smart-contracts/token/test/Blocklist.test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
-import { blocklistFixture } from './fixtures/BlocklistFixtures'
-import { Blocklist } from '../types/generated'
 import { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { blocklistFixture } from './fixtures/BlocklistFixtures'
+import { Blocklist } from '../types/generated'
 
 describe('=> Blocklist', () => {
   let deployer: SignerWithAddress
@@ -32,10 +32,6 @@ describe('=> Blocklist', () => {
 
     it('sets owner to deployer', async () => {
       expect(await blocklist.owner()).to.eq(deployer.address)
-    })
-
-    it('sets blocked accounts index to zero', async () => {
-      expect(await blocklist.getBlockedAllountsIndex()).to.eq(0)
     })
   })
 })


### PR DESCRIPTION
* initialized Blocklist with nominee set in the constructor.
* Also added `_blockedAccountsIndex`, which will be used when resetting the blocklist by incrementing the index.
* Following nested mapping is used to keep track of the blocklist:
 `mapping(uint256 => mapping(address => bool)) private _blockedAccounts;`
* Tests for covering `isAccountBlocked` will be added in the subsequent PR when inside the tests for setting up the blocklist.