### PR TITLE
feat: added method for setting blocklist with relevant tests

### DIFF
--- a/apps/smart-contracts/token/contracts/Blocklist.sol
+++ b/apps/smart-contracts/token/contracts/Blocklist.sol
@@ -12,11 +12,12 @@ contract Blocklist is IBlocklist, SafeOwnable {
     transferOwnership(_nominatedOwner);
   }
 
-  function set(address[] calldata _accounts, bool[] calldata _blocked)
-    external
-    override
-    onlyOwner
-  {}
+  function set(address[] calldata _accounts, bool[] calldata _blocked) external override onlyOwner {
+    require(_accounts.length == _blocked.length, "Array length mismatch");
+    for (uint256 i; i < _accounts.length; ++i) {
+      _blockedAccounts[_blockedAccountsIndex][_accounts[i]] = _blocked[i];
+    }
+  }
 
   function reset(address[] calldata _newBlockedAccounts) external override onlyOwner {}
 

--- a/apps/smart-contracts/token/contracts/Blocklist.sol
+++ b/apps/smart-contracts/token/contracts/Blocklist.sol
@@ -12,14 +12,10 @@ contract Blocklist is IBlocklist, SafeOwnable {
     transferOwnership(_nominatedOwner);
   }
 
-  function set(address[] calldata _accounts, bool[] calldata _blocked)
-    external
-    override
-    onlyOwner
-  {
+  function set(address[] calldata _accounts, bool[] calldata _blocked) external override onlyOwner {
     require(_accounts.length == _blocked.length, "Array length mismatch");
     for (uint256 i; i < _accounts.length; ++i) {
-      _blockedAccounts[_blockedAccountsIndex][_accounts[i]] = _blocked[i];
+      _resetIndexToAccountToBlocked[_resetIndex][_accounts[i]] = _blocked[i];
     }
   }
 

--- a/apps/smart-contracts/token/contracts/Blocklist.sol
+++ b/apps/smart-contracts/token/contracts/Blocklist.sol
@@ -5,9 +5,26 @@ import "./interfaces/IBlocklist.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 contract Blocklist is IBlocklist, SafeOwnable {
-  constructor(address _nominatedOwner) {}
+  uint256 private _blockedAccountsIndex;
+  mapping(uint256 => mapping(address => bool)) private _blockedAccounts;
 
-  function set(address[] calldata _accounts, bool[] calldata _blocked) external override onlyOwner {}
+  constructor(address _nominatedOwner) {
+    transferOwnership(_nominatedOwner);
+  }
 
-  function reset(address[] calldata _blockedAccounts) external override onlyOwner {}
+  function set(address[] calldata _accounts, bool[] calldata _blocked)
+    external
+    override
+    onlyOwner
+  {}
+
+  function reset(address[] calldata _newBlockedAccounts) external override onlyOwner {}
+
+  function isAccountBlocked(address _account) external view override returns (bool) {
+    return _blockedAccounts[_blockedAccountsIndex][_account];
+  }
+
+  function getBlockedAllountsIndex() external view override returns (uint256) {
+    return _blockedAccountsIndex;
+  }
 }

--- a/apps/smart-contracts/token/contracts/interfaces/IBlocklist.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IBlocklist.sol
@@ -6,4 +6,8 @@ interface IBlocklist {
   function set(address[] calldata accounts, bool[] calldata blocked) external;
 
   function reset(address[] calldata blockedAccounts) external;
+
+  function isAccountBlocked(address account) external view returns (bool);
+
+  function getBlockedAllountsIndex() external view returns (uint256);
 }

--- a/apps/smart-contracts/token/test/Blocklist.test.ts
+++ b/apps/smart-contracts/token/test/Blocklist.test.ts
@@ -1,5 +1,41 @@
 import { expect } from 'chai'
 import { blocklistFixture } from './fixtures/BlocklistFixtures'
 import { Blocklist } from '../types/generated'
+import { ethers } from 'hardhat'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-describe('=> Blocklist', () => {})
+describe('=> Blocklist', () => {
+  let deployer: SignerWithAddress
+  let owner: SignerWithAddress
+  let user1: SignerWithAddress
+  let blocklist: Blocklist
+
+  const deployBlocklist = async (): Promise<void> => {
+    ;[deployer, owner, user1] = await ethers.getSigners()
+    blocklist = await blocklistFixture(owner.address)
+  }
+
+  const setupBlocklist = async (): Promise<void> => {
+    await deployBlocklist()
+    await blocklist.connect(owner).acceptOwnership()
+  }
+
+  describe('initial state', () => {
+    beforeEach(async () => {
+      await deployBlocklist()
+    })
+
+    it('sets nominee from initialize', async () => {
+      expect(await blocklist.getNominee()).to.not.eq(deployer.address)
+      expect(await blocklist.getNominee()).to.eq(owner.address)
+    })
+
+    it('sets owner to deployer', async () => {
+      expect(await blocklist.owner()).to.eq(deployer.address)
+    })
+
+    it('sets blocked accounts index to zero', async () => {
+      expect(await blocklist.getBlockedAllountsIndex()).to.eq(0)
+    })
+  })
+})

--- a/apps/smart-contracts/token/test/Blocklist.test.ts
+++ b/apps/smart-contracts/token/test/Blocklist.test.ts
@@ -7,16 +7,26 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 describe('=> Blocklist', () => {
   let deployer: SignerWithAddress
   let owner: SignerWithAddress
-  let user1: SignerWithAddress
+  let blockedUser1: SignerWithAddress
+  let blockedUser2: SignerWithAddress
+  let unblockedUser1: SignerWithAddress
+  let unblockedUser2: SignerWithAddress
   let blocklist: Blocklist
+  let blockedUsersArray: string[]
+  let unblockedUsersArray: string[]
+  const blockedArray = [true, true]
+  const unblockedArray = [false, false]
 
   const deployBlocklist = async (): Promise<void> => {
-    ;[deployer, owner, user1] = await ethers.getSigners()
+    ;[deployer, owner, blockedUser1, blockedUser2, unblockedUser1, unblockedUser2] =
+      await ethers.getSigners()
     blocklist = await blocklistFixture(owner.address)
   }
 
   const setupBlocklist = async (): Promise<void> => {
     await deployBlocklist()
+    blockedUsersArray = [blockedUser1.address, blockedUser2.address]
+    unblockedUsersArray = [unblockedUser1.address, unblockedUser1.address]
     await blocklist.connect(owner).acceptOwnership()
   }
 
@@ -36,6 +46,81 @@ describe('=> Blocklist', () => {
 
     it('sets blocked accounts index to zero', async () => {
       expect(await blocklist.getBlockedAllountsIndex()).to.eq(0)
+    })
+  })
+
+  describe('# set', () => {
+    beforeEach(async () => {
+      await setupBlocklist()
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await blocklist.owner()).to.not.eq(blockedUser1.address)
+
+      await expect(
+        blocklist.connect(blockedUser1).set(blockedUsersArray, blockedArray)
+      ).revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('reverts if array length mismatch', async () => {
+      expect([blockedUser1.address].length).to.not.be.eq(blockedArray.length)
+
+      await expect(blocklist.connect(owner).set([blockedUser1.address], blockedArray)).revertedWith(
+        'Array length mismatch'
+      )
+    })
+
+    it('blocks single account', async () => {
+      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(false)
+
+      await blocklist.connect(owner).set([blockedUser1.address], [true])
+
+      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(true)
+    })
+
+    it('blocks multiple accounts', async () => {
+      for (let i = 0; i < blockedUsersArray.length; i++) {
+        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(false)
+      }
+
+      await blocklist.connect(owner).set(blockedUsersArray, blockedArray)
+
+      for (let i = 0; i < blockedUsersArray.length; i++) {
+        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(true)
+      }
+    })
+
+    it('unblocks single account', async () => {
+      await blocklist.connect(owner).set([unblockedUser1.address], [true])
+      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(true)
+
+      await blocklist.connect(owner).set([unblockedUser1.address], [false])
+
+      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(false)
+    })
+
+    it('unblocks multiple accounts', async () => {
+      for (let i = 0; i < unblockedUsersArray.length; i++) {
+        await blocklist.connect(owner).set([unblockedUsersArray[i]], [true])
+        expect(await blocklist.isAccountBlocked(unblockedUsersArray[i])).to.eq(true)
+      }
+
+      await blocklist.connect(owner).set(unblockedUsersArray, unblockedArray)
+
+      for (let i = 0; i < unblockedUsersArray.length; i++) {
+        expect(await blocklist.isAccountBlocked(unblockedUsersArray[i])).to.eq(false)
+      }
+    })
+
+    it('blocks and unblocks accounts', async () => {
+      await blocklist.connect(owner).set([unblockedUser1.address], [true])
+      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(true)
+      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(false)
+
+      await blocklist.connect(owner).set([blockedUser1.address, unblockedUser1.address], [true, false])
+
+      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(false)
+      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(true)
     })
   })
 })

--- a/apps/smart-contracts/token/test/Blocklist.test.ts
+++ b/apps/smart-contracts/token/test/Blocklist.test.ts
@@ -68,79 +68,85 @@ describe('=> Blocklist', () => {
     })
 
     it('blocks single account', async () => {
-      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(false)
+      expect(await blocklist.isBlocked(blockedUser1.address)).to.eq(false)
 
       await blocklist.connect(owner).set([blockedUser1.address], [true])
 
-      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(true)
+      expect(await blocklist.isBlocked(blockedUser1.address)).to.eq(true)
     })
 
     it('blocks multiple accounts', async () => {
       for (let i = 0; i < blockedUsersArray.length; i++) {
-        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(false)
+        expect(await blocklist.isBlocked(blockedUsersArray[i])).to.eq(false)
       }
 
       await blocklist.connect(owner).set(blockedUsersArray, blockedArray)
 
       for (let i = 0; i < blockedUsersArray.length; i++) {
-        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(true)
+        expect(await blocklist.isBlocked(blockedUsersArray[i])).to.eq(true)
       }
     })
 
     it('unblocks single account', async () => {
       await blocklist.connect(owner).set([unblockedUser1.address], [true])
-      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(true)
+      expect(await blocklist.isBlocked(unblockedUser1.address)).to.eq(true)
 
       await blocklist.connect(owner).set([unblockedUser1.address], [false])
 
-      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(false)
+      expect(await blocklist.isBlocked(unblockedUser1.address)).to.eq(false)
     })
 
     it('unblocks multiple accounts', async () => {
       for (let i = 0; i < unblockedUsersArray.length; i++) {
         await blocklist.connect(owner).set([unblockedUsersArray[i]], [true])
-        expect(await blocklist.isAccountBlocked(unblockedUsersArray[i])).to.eq(true)
+        expect(await blocklist.isBlocked(unblockedUsersArray[i])).to.eq(true)
       }
 
       await blocklist.connect(owner).set(unblockedUsersArray, unblockedArray)
 
       for (let i = 0; i < unblockedUsersArray.length; i++) {
-        expect(await blocklist.isAccountBlocked(unblockedUsersArray[i])).to.eq(false)
+        expect(await blocklist.isBlocked(unblockedUsersArray[i])).to.eq(false)
       }
     })
 
     it('blocks and unblocks accounts', async () => {
       await blocklist.connect(owner).set([unblockedUser1.address], [true])
-      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(true)
-      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(false)
+      expect(await blocklist.isBlocked(unblockedUser1.address)).to.eq(true)
+      expect(await blocklist.isBlocked(blockedUser1.address)).to.eq(false)
 
       await blocklist
         .connect(owner)
-        .set([blockedUser1.address, unblockedUser1.address], [true, false])
+        .set([unblockedUser1.address, blockedUser1.address], [false, true])
 
-      expect(await blocklist.isAccountBlocked(unblockedUser1.address)).to.eq(false)
-      expect(await blocklist.isAccountBlocked(blockedUser1.address)).to.eq(true)
+      expect(await blocklist.isBlocked(unblockedUser1.address)).to.eq(false)
+      expect(await blocklist.isBlocked(blockedUser1.address)).to.eq(true)
+    })
+
+    it('sets lattermost bool value if account passed multiple times', async () => {
+      expect(await blocklist.isBlocked(blockedUser1.address)).to.eq(false)
+
+      await blocklist
+        .connect(owner)
+        .set([blockedUser1.address, blockedUser1.address], [true, false])
+
+      expect(await blocklist.isBlocked(blockedUser1.address)).to.eq(false)
     })
 
     it('is idempotent', async () => {
       for (let i = 0; i < blockedUsersArray.length; i++) {
-        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(false)
+        expect(await blocklist.isBlocked(blockedUsersArray[i])).to.eq(false)
       }
 
       await blocklist.connect(owner).set(blockedUsersArray, blockedArray)
 
       for (let i = 0; i < blockedUsersArray.length; i++) {
-        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(true)
-      }
-
-      for (let i = 0; i < blockedUsersArray.length; i++) {
-        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(true)
+        expect(await blocklist.isBlocked(blockedUsersArray[i])).to.eq(true)
       }
 
       await blocklist.connect(owner).set(blockedUsersArray, blockedArray)
 
       for (let i = 0; i < blockedUsersArray.length; i++) {
-        expect(await blocklist.isAccountBlocked(blockedUsersArray[i])).to.eq(true)
+        expect(await blocklist.isBlocked(blockedUsersArray[i])).to.eq(true)
       }
     })
   })


### PR DESCRIPTION
* Adding method to set blocklist for accounts using the `set(address[] calldata _accounts, bool[] calldata _blocked)` 
* Added relevant tests for checking the following blocking/unblocking scenarios:
  1. Blocking a single account
  2. Blocking multiple accounts
  3. Unblocking a single account
  4. Unblocking multiple accounts
  5. Blocking and unblocking accounts in a single call (i.e blocking one account while unblocking another)