### PR TITLE
feat: added reset method and relevant tests

### DIFF
--- a/apps/smart-contracts/token/contracts/Blocklist.sol
+++ b/apps/smart-contracts/token/contracts/Blocklist.sol
@@ -19,7 +19,12 @@ contract Blocklist is IBlocklist, SafeOwnable {
     }
   }
 
-  function reset(address[] calldata _newBlockedAccounts) external override onlyOwner {}
+  function reset(address[] calldata _newBlockedAccounts) external override onlyOwner {
+    _blockedAccountsIndex++;
+    for (uint256 i; i < _newBlockedAccounts.length; ++i) {
+      _blockedAccounts[_blockedAccountsIndex][_newBlockedAccounts[i]] = true;
+    }
+  }
 
   function isAccountBlocked(address _account) external view override returns (bool) {
     return _blockedAccounts[_blockedAccountsIndex][_account];


### PR DESCRIPTION
* Adding method to reset blocklist.
* When an empty array is passed in it simply increments the `_blockedAccountsIndex` and thus resetting the `_blockedAccounts` list. 
* Whereas when `_newBlockedAccounts` are passed then `_blockedAccountsIndex` is incremented and at the same time new accounts are added to the blockedAccounts list (all the new accounts added are automatically blocked). So it essentially replaces the `_blockedAccounts` list with `_newBlockedAccounts`.