### PR TITLE
feat: initialized Allowlist and added relavant tests

### DIFF
--- a/apps/smart-contracts/token/contracts/Allowlist.sol
+++ b/apps/smart-contracts/token/contracts/Allowlist.sol
@@ -5,7 +5,14 @@ import "./interfaces/IAllowlist.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 contract Allowlist is IAllowlist, SafeOwnable {
-  constructor(address _nominatedOwner) {}
+  uint256 private _sourceAccountsIndex;
+  uint256 private _destinationAccountsIndex;
+  mapping(uint256 => mapping(address => bool)) private _allowedSourceAccounts;
+  mapping(uint256 => mapping(address => bool)) private _allowedDestinationAccounts;
+
+  constructor(address _nominatedOwner) {
+    transferOwnership(_nominatedOwner);
+  }
 
   function setDestinations(address[] calldata _destinations, bool[] calldata _allowed)
     external
@@ -22,4 +29,20 @@ contract Allowlist is IAllowlist, SafeOwnable {
   {}
 
   function resetSources(address[] calldata _allowedSources) external override onlyOwner {}
+
+  function getSourceAccountsIndex() external view override returns (uint256) {
+    return _sourceAccountsIndex;
+  }
+
+  function getDestinationAccountsIndex() external view override returns (uint256) {
+    return _destinationAccountsIndex;
+  }
+
+  function isAccountSourceAllowed(address _account) external view override returns (bool) {
+    return _allowedSourceAccounts[_sourceAccountsIndex][_account];
+  }
+
+  function isAccountDestinationAllowed(address _account) external view override returns (bool) {
+    return _allowedDestinationAccounts[_destinationAccountsIndex][_account];
+  }
 }

--- a/apps/smart-contracts/token/contracts/Allowlist.sol
+++ b/apps/smart-contracts/token/contracts/Allowlist.sol
@@ -5,10 +5,10 @@ import "./interfaces/IAllowlist.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 contract Allowlist is IAllowlist, SafeOwnable {
-  uint256 private _sourceAccountsIndex;
-  uint256 private _destinationAccountsIndex;
-  mapping(uint256 => mapping(address => bool)) private _allowedSourceAccounts;
-  mapping(uint256 => mapping(address => bool)) private _allowedDestinationAccounts;
+  uint256 private _sourceIndex;
+  uint256 private _destinationIndex;
+  mapping(uint256 => mapping(address => bool)) private _sourceIndexToAccountToAllowed;
+  mapping(uint256 => mapping(address => bool)) private _destinationIndexToAccountToAllowed;
 
   constructor(address _nominatedOwner) {
     transferOwnership(_nominatedOwner);
@@ -30,11 +30,11 @@ contract Allowlist is IAllowlist, SafeOwnable {
 
   function resetSources(address[] calldata _sourcesToAllow) external override onlyOwner {}
 
-    function isAccountSourceAllowed(address _account) external view override returns (bool) {
-        return _allowedSourceAccounts[_sourceAccountsIndex][_account];
-    }
+  function isSourceAllowed(address _account) external view override returns (bool) {
+    return _sourceIndexToAccountToAllowed[_sourceIndex][_account];
+  }
 
-    function isAccountDestinationAllowed(address _account) external view override returns (bool) {
-        return _allowedDestinationAccounts[_destinationAccountsIndex][_account];
-    }
+  function isDestinationAllowed(address _account) external view override returns (bool) {
+    return _destinationIndexToAccountToAllowed[_destinationIndex][_account];
+  }
 }

--- a/apps/smart-contracts/token/contracts/interfaces/IAllowlist.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IAllowlist.sol
@@ -11,7 +11,7 @@ interface IAllowlist {
 
   function resetSources(address[] calldata sourcesToAllow) external;
 
-    function isAccountSourceAllowed(address account) external view returns (bool);
+  function isSourceAllowed(address account) external view returns (bool);
 
-    function isAccountDestinationAllowed(address account) external view returns (bool);
+  function isDestinationAllowed(address account) external view returns (bool);
 }

--- a/apps/smart-contracts/token/contracts/interfaces/IAllowlist.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IAllowlist.sol
@@ -10,4 +10,12 @@ interface IAllowlist {
   function setSources(address[] calldata sources, bool[] calldata allowed) external;
 
   function resetSources(address[] calldata allowedSources) external;
+
+  function getSourceAccountsIndex() external view returns (uint256);
+
+  function getDestinationAccountsIndex() external view returns (uint256);
+
+  function isAccountSourceAllowed(address account) external view returns (bool);
+
+  function isAccountDestinationAllowed(address account) external view returns (bool);
 }

--- a/apps/smart-contracts/token/test/Allowlist.test.ts
+++ b/apps/smart-contracts/token/test/Allowlist.test.ts
@@ -33,13 +33,5 @@ describe('=> Allowlist', () => {
     it('sets owner to deployer', async () => {
       expect(await allowlist.owner()).to.eq(deployer.address)
     })
-
-    it('sets source accounts index to zero', async () => {
-      expect(await allowlist.getSourceAccountsIndex()).to.eq(0)
-    })
-
-    it('sets destination accounts index to zero', async () => {
-      expect(await allowlist.getDestinationAccountsIndex()).to.eq(0)
-    })
   })
 })

--- a/apps/smart-contracts/token/test/Allowlist.test.ts
+++ b/apps/smart-contracts/token/test/Allowlist.test.ts
@@ -1,5 +1,45 @@
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { allowlistFixture } from './fixtures/AllowlistFixtures'
 import { Allowlist } from '../types/generated'
 
-describe('=> Allowlist', () => {})
+describe('=> Allowlist', () => {
+  let deployer: SignerWithAddress
+  let owner: SignerWithAddress
+  let user1: SignerWithAddress
+  let allowlist: Allowlist
+
+  const deployAllowlist = async (): Promise<void> => {
+    ;[deployer, owner, user1] = await ethers.getSigners()
+    allowlist = await allowlistFixture(owner.address)
+  }
+
+  const setupAllowlist = async (): Promise<void> => {
+    await deployAllowlist()
+    await allowlist.connect(owner).acceptOwnership()
+  }
+
+  describe('initial state', () => {
+    beforeEach(async () => {
+      await deployAllowlist()
+    })
+
+    it('sets nominee from initialize', async () => {
+      expect(await allowlist.getNominee()).to.not.eq(deployer.address)
+      expect(await allowlist.getNominee()).to.eq(owner.address)
+    })
+
+    it('sets owner to deployer', async () => {
+      expect(await allowlist.owner()).to.eq(deployer.address)
+    })
+
+    it('sets source accounts index to zero', async () => {
+      expect(await allowlist.getSourceAccountsIndex()).to.eq(0)
+    })
+
+    it('sets destination accounts index to zero', async () => {
+      expect(await allowlist.getDestinationAccountsIndex()).to.eq(0)
+    })
+  })
+})


### PR DESCRIPTION
* initialized Allowlist contract with nominee set in the constructor.
* Also added `_sourceIndex` and `_destinationIndex`, which will be used when resetting the source and destination allowed lists by incrementing the index.
* Following nested mappings are used to keep track of the source and destination lists:
 `mapping(uint256 => mapping(address => bool)) private _sourceIndexToAccountToAllowed;`
  `mapping(uint256 => mapping(address => bool)) private _destinationIndexToAccountToAllowed;`
