### PR TITLE
feat: adding set and reset Destinations methods with relevant tests

### DIFF
--- a/apps/smart-contracts/token/contracts/Allowlist.sol
+++ b/apps/smart-contracts/token/contracts/Allowlist.sol
@@ -18,9 +18,19 @@ contract Allowlist is IAllowlist, SafeOwnable {
     external
     override
     onlyOwner
-  {}
+  {
+    require(_destinations.length == _allowed.length, "Array length mismatch");
+    for (uint256 i; i < _destinations.length; ++i) {
+      _destinationIndexToAccountToAllowed[_destinationIndex][_destinations[i]] = _allowed[i];
+    }
+  }
 
-  function resetDestinations(address[] calldata _destinationsToAllow) external override onlyOwner {}
+  function resetDestinations(address[] calldata _destinationsToAllow) external override onlyOwner {
+    _destinationIndex++;
+    for (uint256 i; i < _destinationsToAllow.length; ++i) {
+      _destinationIndexToAccountToAllowed[_destinationIndex][_destinationsToAllow[i]] = true;
+    }
+  }
 
   function setSources(address[] calldata _sources, bool[] calldata _allowed)
     external

--- a/apps/smart-contracts/token/test/Allowlist.test.ts
+++ b/apps/smart-contracts/token/test/Allowlist.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
@@ -7,16 +8,38 @@ import { Allowlist } from '../types/generated'
 describe('=> Allowlist', () => {
   let deployer: SignerWithAddress
   let owner: SignerWithAddress
-  let user1: SignerWithAddress
+  let allowedUser1: SignerWithAddress
+  let allowedUser2: SignerWithAddress
+  let disallowedUser1: SignerWithAddress
+  let disallowedUser2: SignerWithAddress
+  let newAllowedUser1: SignerWithAddress
+  let newAllowedUser2: SignerWithAddress
   let allowlist: Allowlist
+  let allowedUsersArray: string[]
+  let disallowedUsersArray: string[]
+  let newAllowedUsersArray: string[]
+  const allowedArray = [true, true]
+  const disallowedArray = [false, false]
 
   const deployAllowlist = async (): Promise<void> => {
-    ;[deployer, owner, user1] = await ethers.getSigners()
+    ;[
+      deployer,
+      owner,
+      allowedUser1,
+      allowedUser2,
+      disallowedUser1,
+      disallowedUser2,
+      newAllowedUser1,
+      newAllowedUser2,
+    ] = await ethers.getSigners()
     allowlist = await allowlistFixture(owner.address)
   }
 
   const setupAllowlist = async (): Promise<void> => {
     await deployAllowlist()
+    allowedUsersArray = [allowedUser1.address, allowedUser2.address]
+    disallowedUsersArray = [disallowedUser1.address, disallowedUser2.address]
+    newAllowedUsersArray = [newAllowedUser1.address, newAllowedUser2.address]
     await allowlist.connect(owner).acceptOwnership()
   }
 
@@ -25,13 +48,173 @@ describe('=> Allowlist', () => {
       await deployAllowlist()
     })
 
-    it('sets nominee from initialize', async () => {
+    it('setDestinationss nominee from initialize', async () => {
       expect(await allowlist.getNominee()).to.not.eq(deployer.address)
       expect(await allowlist.getNominee()).to.eq(owner.address)
     })
 
-    it('sets owner to deployer', async () => {
+    it('setDestinationss owner to deployer', async () => {
       expect(await allowlist.owner()).to.eq(deployer.address)
+    })
+  })
+
+  describe('# setDestinations', () => {
+    beforeEach(async () => {
+      await setupAllowlist()
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await allowlist.owner()).to.not.eq(allowedUser1.address)
+
+      await expect(
+        allowlist.connect(allowedUser1).setDestinations(allowedUsersArray, allowedArray)
+      ).revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('reverts if array length mismatch', async () => {
+      expect([allowedUser1.address].length).to.not.be.eq(allowedArray.length)
+
+      await expect(
+        allowlist.connect(owner).setDestinations([allowedUser1.address], allowedArray)
+      ).revertedWith('Array length mismatch')
+    })
+
+    it('allows single account', async () => {
+      expect(await allowlist.isDestinationAllowed(allowedUser1.address)).to.eq(false)
+
+      await allowlist.connect(owner).setDestinations([allowedUser1.address], [true])
+
+      expect(await allowlist.isDestinationAllowed(allowedUser1.address)).to.eq(true)
+    })
+
+    it('allows multiple accounts', async () => {
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(false)
+      }
+
+      await allowlist.connect(owner).setDestinations(allowedUsersArray, allowedArray)
+
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(true)
+      }
+    })
+
+    it('disallows single account', async () => {
+      await allowlist.connect(owner).setDestinations([disallowedUser1.address], [true])
+      expect(await allowlist.isDestinationAllowed(disallowedUser1.address)).to.eq(true)
+
+      await allowlist.connect(owner).setDestinations([disallowedUser1.address], [false])
+
+      expect(await allowlist.isDestinationAllowed(disallowedUser1.address)).to.eq(false)
+    })
+
+    it('disallows multiple accounts', async () => {
+      for (let i = 0; i < disallowedUsersArray.length; i++) {
+        await allowlist.connect(owner).setDestinations([disallowedUsersArray[i]], [true])
+        expect(await allowlist.isDestinationAllowed(disallowedUsersArray[i])).to.eq(true)
+      }
+
+      await allowlist.connect(owner).setDestinations(disallowedUsersArray, disallowedArray)
+
+      for (let i = 0; i < disallowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(disallowedUsersArray[i])).to.eq(false)
+      }
+    })
+
+    it('allows and disallows accounts', async () => {
+      await allowlist.connect(owner).setDestinations([disallowedUser1.address], [true])
+      expect(await allowlist.isDestinationAllowed(disallowedUser1.address)).to.eq(true)
+      expect(await allowlist.isDestinationAllowed(allowedUser1.address)).to.eq(false)
+
+      await allowlist
+        .connect(owner)
+        .setDestinations([disallowedUser1.address, allowedUser1.address], [false, true])
+
+      expect(await allowlist.isDestinationAllowed(disallowedUser1.address)).to.eq(false)
+      expect(await allowlist.isDestinationAllowed(allowedUser1.address)).to.eq(true)
+    })
+
+    it('setDestinationss lattermost bool value if account passed multiple times', async () => {
+      expect(await allowlist.isDestinationAllowed(allowedUser1.address)).to.eq(false)
+
+      await allowlist
+        .connect(owner)
+        .setDestinations([allowedUser1.address, allowedUser1.address], [true, false])
+
+      expect(await allowlist.isDestinationAllowed(allowedUser1.address)).to.eq(false)
+    })
+
+    it('is idempotent', async () => {
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(false)
+      }
+
+      await allowlist.connect(owner).setDestinations(allowedUsersArray, allowedArray)
+
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(true)
+      }
+
+      await allowlist.connect(owner).setDestinations(allowedUsersArray, allowedArray)
+
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(true)
+      }
+    })
+  })
+
+  describe('# resetDestinations', () => {
+    beforeEach(async () => {
+      await setupAllowlist()
+      await allowlist.connect(owner).setDestinations(allowedUsersArray, allowedArray)
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await allowlist.owner()).to.not.eq(allowedUser1.address)
+
+      await expect(
+        allowlist.connect(allowedUser1).resetDestinations(allowedUsersArray)
+      ).revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('clears list if not setting new list', async () => {
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(true)
+      }
+
+      await allowlist.connect(owner).resetDestinations([])
+
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(false)
+      }
+    })
+
+    it('replaces old list with one account', async () => {
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(true)
+      }
+      expect(await allowlist.isDestinationAllowed(newAllowedUser1.address)).to.eq(false)
+
+      await allowlist.connect(owner).resetDestinations([newAllowedUser1.address])
+
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(false)
+      }
+      expect(await allowlist.isDestinationAllowed(newAllowedUser1.address)).to.eq(true)
+    })
+
+    it('replaces old list with multiple accounts', async () => {
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(true)
+        expect(await allowlist.isDestinationAllowed(newAllowedUsersArray[i])).to.eq(false)
+      }
+
+      await allowlist.connect(owner).resetDestinations(newAllowedUsersArray)
+
+      for (let i = 0; i < allowedUsersArray.length; i++) {
+        expect(await allowlist.isDestinationAllowed(allowedUsersArray[i])).to.eq(false)
+        expect(await allowlist.isDestinationAllowed(newAllowedUsersArray[i])).to.eq(true)
+      }
     })
   })
 })


### PR DESCRIPTION
* Adding method to set and reset destination.
* Submitting both simultaneously as the tests are pretty similar to set and reset of blocklist.
* `_destinationIndex` is incremented every time we perform `resetDestinations`
* We keep a track of destination allowed accounts by `mapping(uint256 => mapping(address => bool)) private _destinationIndexToAccountToAllowed;`