### PR TITLE
feat: added set and reset implementations

### DIFF
--- a/apps/smart-contracts/token/contracts/AccountList.sol
+++ b/apps/smart-contracts/token/contracts/AccountList.sol
@@ -12,9 +12,23 @@ contract AccountList is IAccountList, SafeOwnable {
     transferOwnership(_nominatedOwner);
   }
 
-  function set(address[] calldata accounts, bool[] calldata included) external override onlyOwner {}
+  function set(address[] calldata _accounts, bool[] calldata _included)
+    external
+    override
+    onlyOwner
+  {
+    require(_accounts.length == _included.length, "Array length mismatch");
+    for (uint256 i; i < _accounts.length; ++i) {
+      _resetIndexToAccountToIncluded[_resetIndex][_accounts[i]] = _included[i];
+    }
+  }
 
-  function reset(address[] calldata _newIncludedAccounts) external override onlyOwner {}
+  function reset(address[] calldata _newIncludedAccounts) external override onlyOwner {
+    _resetIndex++;
+    for (uint256 i; i < _newIncludedAccounts.length; ++i) {
+      _resetIndexToAccountToIncluded[_resetIndex][_newIncludedAccounts[i]] = true;
+    }
+  }
 
   function getResetIndex() external view override returns (uint256) {
     return _resetIndex;

--- a/apps/smart-contracts/token/test/AccountList.test.ts
+++ b/apps/smart-contracts/token/test/AccountList.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
@@ -8,17 +9,38 @@ import { AccountList } from '../types/generated'
 describe('=> AccountList', () => {
   let deployer: SignerWithAddress
   let owner: SignerWithAddress
-  let user1: SignerWithAddress
-  let user2: SignerWithAddress
+  let includedUser1: SignerWithAddress
+  let includedUser2: SignerWithAddress
+  let unincludedUser1: SignerWithAddress
+  let unincludedUser2: SignerWithAddress
+  let newIncludedUser1: SignerWithAddress
+  let newIncludedUser2: SignerWithAddress
   let accountList: AccountList
+  let includedUsersArray: string[]
+  let unincludedUsersArray: string[]
+  let newIncludedUsersArray: string[]
+  const blockedArray = [true, true]
+  const unblockedArray = [false, false]
 
   const deployAccountList = async (): Promise<void> => {
-    ;[deployer, owner, user1, user2] = await ethers.getSigners()
+    ;[
+      deployer,
+      owner,
+      includedUser1,
+      includedUser2,
+      unincludedUser1,
+      unincludedUser2,
+      newIncludedUser1,
+      newIncludedUser2,
+    ] = await ethers.getSigners()
     accountList = await accountListFixture(owner.address)
   }
 
   const setupAccountList = async (): Promise<void> => {
     await deployAccountList()
+    includedUsersArray = [includedUser1.address, includedUser2.address]
+    unincludedUsersArray = [unincludedUser1.address, unincludedUser2.address]
+    newIncludedUsersArray = [newIncludedUser1.address, newIncludedUser2.address]
     await accountList.connect(owner).acceptOwnership()
   }
 
@@ -34,6 +56,166 @@ describe('=> AccountList', () => {
 
     it('sets owner to deployer', async () => {
       expect(await accountList.owner()).to.eq(deployer.address)
+    })
+  })
+
+  describe('# set', () => {
+    beforeEach(async () => {
+      await setupAccountList()
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await accountList.owner()).to.not.eq(includedUser1.address)
+
+      await expect(
+        accountList.connect(includedUser1).set(includedUsersArray, blockedArray)
+      ).revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('reverts if array length mismatch', async () => {
+      expect([includedUser1.address].length).to.not.be.eq(blockedArray.length)
+
+      await expect(
+        accountList.connect(owner).set([includedUser1.address], blockedArray)
+      ).revertedWith('Array length mismatch')
+    })
+
+    it('blocks single account', async () => {
+      expect(await accountList.isIncluded(includedUser1.address)).to.eq(false)
+
+      await accountList.connect(owner).set([includedUser1.address], [true])
+
+      expect(await accountList.isIncluded(includedUser1.address)).to.eq(true)
+    })
+
+    it('blocks multiple accounts', async () => {
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(false)
+      }
+
+      await accountList.connect(owner).set(includedUsersArray, blockedArray)
+
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(true)
+      }
+    })
+
+    it('unblocks single account', async () => {
+      await accountList.connect(owner).set([unincludedUser1.address], [true])
+      expect(await accountList.isIncluded(unincludedUser1.address)).to.eq(true)
+
+      await accountList.connect(owner).set([unincludedUser1.address], [false])
+
+      expect(await accountList.isIncluded(unincludedUser1.address)).to.eq(false)
+    })
+
+    it('unblocks multiple accounts', async () => {
+      for (let i = 0; i < unincludedUsersArray.length; i++) {
+        await accountList.connect(owner).set([unincludedUsersArray[i]], [true])
+        expect(await accountList.isIncluded(unincludedUsersArray[i])).to.eq(true)
+      }
+
+      await accountList.connect(owner).set(unincludedUsersArray, unblockedArray)
+
+      for (let i = 0; i < unincludedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(unincludedUsersArray[i])).to.eq(false)
+      }
+    })
+
+    it('blocks and unblocks accounts', async () => {
+      await accountList.connect(owner).set([unincludedUser1.address], [true])
+      expect(await accountList.isIncluded(unincludedUser1.address)).to.eq(true)
+      expect(await accountList.isIncluded(includedUser1.address)).to.eq(false)
+
+      await accountList
+        .connect(owner)
+        .set([unincludedUser1.address, includedUser1.address], [false, true])
+
+      expect(await accountList.isIncluded(unincludedUser1.address)).to.eq(false)
+      expect(await accountList.isIncluded(includedUser1.address)).to.eq(true)
+    })
+
+    it('sets lattermost bool value if account passed multiple times', async () => {
+      expect(await accountList.isIncluded(includedUser1.address)).to.eq(false)
+
+      await accountList
+        .connect(owner)
+        .set([includedUser1.address, includedUser1.address], [true, false])
+
+      expect(await accountList.isIncluded(includedUser1.address)).to.eq(false)
+    })
+
+    it('is idempotent', async () => {
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(false)
+      }
+
+      await accountList.connect(owner).set(includedUsersArray, blockedArray)
+
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(true)
+      }
+
+      await accountList.connect(owner).set(includedUsersArray, blockedArray)
+
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(true)
+      }
+    })
+  })
+
+  describe('# reset', () => {
+    beforeEach(async () => {
+      await setupAccountList()
+      await accountList.connect(owner).set(includedUsersArray, blockedArray)
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await accountList.owner()).to.not.eq(includedUser1.address)
+
+      await expect(accountList.connect(includedUser1).reset(includedUsersArray)).revertedWith(
+        'Ownable: caller is not the owner'
+      )
+    })
+
+    it('clears list if not setting new list', async () => {
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(true)
+      }
+
+      await accountList.connect(owner).reset([])
+
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(false)
+      }
+    })
+
+    it('replaces old list with one account', async () => {
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(true)
+      }
+      expect(await accountList.isIncluded(newIncludedUser1.address)).to.eq(false)
+
+      await accountList.connect(owner).reset([newIncludedUser1.address])
+
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(false)
+      }
+      expect(await accountList.isIncluded(newIncludedUser1.address)).to.eq(true)
+    })
+
+    it('replaces old list with multiple accounts', async () => {
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(true)
+        expect(await accountList.isIncluded(newIncludedUsersArray[i])).to.eq(false)
+      }
+
+      await accountList.connect(owner).reset(newIncludedUsersArray)
+
+      for (let i = 0; i < includedUsersArray.length; i++) {
+        expect(await accountList.isIncluded(includedUsersArray[i])).to.eq(false)
+        expect(await accountList.isIncluded(newIncludedUsersArray[i])).to.eq(true)
+      }
     })
   })
 })

--- a/apps/smart-contracts/token/test/AccountList.test.ts
+++ b/apps/smart-contracts/token/test/AccountList.test.ts
@@ -136,7 +136,8 @@ describe('=> AccountList', () => {
     })
 
     it('sets lattermost bool value if account passed multiple times', async () => {
-      expect(await accountList.isIncluded(includedUser1.address)).to.eq(false)
+      await accountList.connect(owner).set([includedUser1.address], [true])
+      expect(await accountList.isIncluded(includedUser1.address)).to.eq(true)
 
       await accountList
         .connect(owner)


### PR DESCRIPTION
Tests were taken from the old `Blocklist.test.ts`, except with a modification to the `sets lattermost bool value...` test.

The old test starts with the account not being included, and the latter most value is also false, so there will effectively be no change. I have made it start with the account to be included so there is a change to be reflected.