### PR TITLE
feat: adding unrestricted transfer hook logic

### DIFF
--- a/apps/smart-contracts/token/contracts/BlocklistTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/BlocklistTransferHook.sol
@@ -23,7 +23,10 @@ contract BlocklistTransferHook is IBlocklistTransferHook, SafeOwnable {
     address _from,
     address _to,
     uint256 _amount
-  ) external override onlyToken {}
+  ) external override onlyToken {
+    require(!_blocklist.isIncluded(_from), "Sender blocked");
+    require(!_blocklist.isIncluded(_to), "Recipient blocked");
+  }
 
   function setToken(address _newToken) external onlyOwner {
     _token = _newToken;

--- a/apps/smart-contracts/token/test/BlocklistTransferHook.test.ts
+++ b/apps/smart-contracts/token/test/BlocklistTransferHook.test.ts
@@ -145,54 +145,54 @@ describe('BlocklistTransferHook', () => {
   })
 
   describe('hook', () => {
-    let source: SignerWithAddress
-    let destination: SignerWithAddress
+    let sender: SignerWithAddress
+    let recipient: SignerWithAddress
     beforeEach(async () => {
       await setupHookAndList()
       await blocklistTransferHook.connect(owner).setToken(ppoToken.address)
-      source = user1
-      destination = user2
+      sender = user1
+      recipient = user2
     })
 
     it('reverts if caller is not PPO', async () => {
       expect(await blocklistTransferHook.getToken()).to.not.eq(user1.address)
 
       await expect(
-        blocklistTransferHook.connect(user1).hook(source.address, destination.address, 1)
+        blocklistTransferHook.connect(user1).hook(sender.address, recipient.address, 1)
       ).to.be.revertedWith('msg.sender != token')
     })
 
-    it('reverts if source blocked', async () => {
-      blockedAccounts.isIncluded.whenCalledWith(source.address).returns(true)
+    it('reverts if sender blocked', async () => {
+      blockedAccounts.isIncluded.whenCalledWith(sender.address).returns(true)
 
       await expect(
-        blocklistTransferHook.connect(ppoToken).hook(source.address, destination.address, 1)
+        blocklistTransferHook.connect(ppoToken).hook(sender.address, recipient.address, 1)
       ).to.be.revertedWith('Sender blocked')
     })
 
-    it('reverts if destination blocked', async () => {
-      blockedAccounts.isIncluded.whenCalledWith(destination.address).returns(true)
+    it('reverts if recipient blocked', async () => {
+      blockedAccounts.isIncluded.whenCalledWith(recipient.address).returns(true)
 
       await expect(
-        blocklistTransferHook.connect(ppoToken).hook(source.address, destination.address, 1)
+        blocklistTransferHook.connect(ppoToken).hook(sender.address, recipient.address, 1)
       ).to.be.revertedWith('Recipient blocked')
     })
 
-    it('reverts if both source and destination blocked', async () => {
-      blockedAccounts.isIncluded.whenCalledWith(source.address).returns(true)
-      blockedAccounts.isIncluded.whenCalledWith(destination.address).returns(true)
+    it('reverts if both sender and recipient blocked', async () => {
+      blockedAccounts.isIncluded.whenCalledWith(sender.address).returns(true)
+      blockedAccounts.isIncluded.whenCalledWith(recipient.address).returns(true)
 
       await expect(
-        blocklistTransferHook.connect(ppoToken).hook(source.address, destination.address, 1)
+        blocklistTransferHook.connect(ppoToken).hook(sender.address, recipient.address, 1)
       ).to.be.revertedWith('Sender blocked')
     })
 
-    it("doesn't revert if both source and destination not blocked", async () => {
-      blockedAccounts.isIncluded.whenCalledWith(source.address).returns(false)
-      blockedAccounts.isIncluded.whenCalledWith(destination.address).returns(false)
+    it("doesn't revert if both sender and recipient not blocked", async () => {
+      blockedAccounts.isIncluded.whenCalledWith(sender.address).returns(false)
+      blockedAccounts.isIncluded.whenCalledWith(recipient.address).returns(false)
 
       await expect(
-        blocklistTransferHook.connect(ppoToken).hook(source.address, destination.address, 1)
+        blocklistTransferHook.connect(ppoToken).hook(sender.address, recipient.address, 1)
       ).to.not.reverted
     })
   })

--- a/apps/smart-contracts/token/test/BlocklistTransferHook.test.ts
+++ b/apps/smart-contracts/token/test/BlocklistTransferHook.test.ts
@@ -147,6 +147,7 @@ describe('BlocklistTransferHook', () => {
   describe('hook', () => {
     let sender: SignerWithAddress
     let recipient: SignerWithAddress
+
     beforeEach(async () => {
       await setupHookAndList()
       await blocklistTransferHook.connect(owner).setToken(ppoToken.address)
@@ -154,7 +155,7 @@ describe('BlocklistTransferHook', () => {
       recipient = user2
     })
 
-    it('reverts if caller is not PPO', async () => {
+    it('reverts if caller is not token', async () => {
       expect(await blocklistTransferHook.getToken()).to.not.eq(user1.address)
 
       await expect(


### PR DESCRIPTION
* Adding logic for `hook` of `BlocklistTransferHook`.
* The `hook` checks for the criteria that neither the source nor destination should be on the blocklist.