### PR TITLE
feat: add arbitrum networks, rationalize names for relevant networks

### DIFF
--- a/apps/smart-contracts/core/hardhat.config.ts
+++ b/apps/smart-contracts/core/hardhat.config.ts
@@ -43,8 +43,9 @@ const config: HardhatUserConfig = {
       rinkeby: hardhatLocalConfig.ETHERSCAN_API_KEY,
       goerli: hardhatLocalConfig.ETHERSCAN_API_KEY,
 
-      // optimism
-      optimisticEthereum: hardhatLocalConfig.OPTIMISTIC_ETHERSCAN_API_KEY,
+      // arbitrum
+      arbitrumOne: hardhatLocalConfig.ARBISCAN_API_KEY,
+      arbitrumTestnet: hardhatLocalConfig.ARBISCAN_API_KEY,
 
       // polygon
       polygon: hardhatLocalConfig.POLYGONSCAN_API_KEY,

--- a/apps/smart-contracts/token/hardhat.config.ts
+++ b/apps/smart-contracts/token/hardhat.config.ts
@@ -66,8 +66,9 @@ const config: HardhatUserConfig = {
       rinkeby: hardhatLocalConfig.ETHERSCAN_API_KEY,
       goerli: hardhatLocalConfig.ETHERSCAN_API_KEY,
 
-      // optimism
-      optimisticEthereum: hardhatLocalConfig.OPTIMISTIC_ETHERSCAN_API_KEY,
+      // arbitrum
+      arbitrumOne: hardhatLocalConfig.ARBISCAN_API_KEY,
+      arbitrumTestnet: hardhatLocalConfig.ARBISCAN_API_KEY,
 
       // polygon
       polygon: hardhatLocalConfig.POLYGONSCAN_API_KEY,

--- a/packages/prepo-constants/src/networks.ts
+++ b/packages/prepo-constants/src/networks.ts
@@ -14,7 +14,7 @@ export enum ChainId {
   Theta = 361,
   ThetaTestnet = 365,
   Moonriver = 1285,
-  Mumbai = 80001,
+  PolygonMumbai = 80001,
   Harmony = 1666600000,
   Palm = 11297108109,
   Localhost = 1337,
@@ -36,11 +36,11 @@ export type SupportedNetworks =
   | 'goerli'
   | 'xdai'
   | 'polygon'
-  | 'mumbai'
+  | 'polygonMumbai'
   | 'smartchain'
   | 'smartchaintest'
-  | 'arbitrumone'
-  | 'arbitrumtestnet'
+  | 'arbitrumOne'
+  | 'arbitrumTestnet'
 
 export type Network = {
   name: SupportedNetworks
@@ -165,11 +165,11 @@ export const NETWORKS: Networks = {
     type: 'polygon',
     testNetwork: false,
   },
-  mumbai: {
+  polygonMumbai: {
     chainName: 'Polygon Testnet',
-    name: 'mumbai',
+    name: 'polygonMumbai',
     color: '#92D9FA',
-    chainId: ChainId.Mumbai,
+    chainId: ChainId.PolygonMumbai,
     rpcUrls: ['https://rpc-mumbai.maticvigil.com'],
     faucet: 'https://faucet.matic.network',
     blockExplorer: 'https://mumbai-explorer.matic.today',
@@ -197,21 +197,23 @@ export const NETWORKS: Networks = {
     type: 'bsc',
     testNetwork: true,
   },
-  arbitrumone: {
-    name: 'arbitrumone',
+  arbitrumOne: {
     chainName: 'Arbitrum One',
+    name: 'arbitrumOne',
     color: '#2BA0EF',
     chainId: ChainId.ArbitrumOne,
+    infuraEndpointName: 'arbitrum-mainnet',
     rpcUrls: ['https://arb1.arbitrum.io/rpc'],
     blockExplorer: 'https://arbiscan.io/',
     type: 'arbitrum',
     testNetwork: false,
   },
-  arbitrumtestnet: {
-    name: 'arbitrumtestnet',
+  arbitrumTestnet: {
     chainName: 'Arbitrum Testnet',
+    name: 'arbitrumTestnet',
     color: '#2BA0EF',
     chainId: ChainId.ArbitrumTestnet,
+    infuraEndpointName: 'arbitrum-rinkeby',
     rpcUrls: ['https://rinkeby.arbitrum.io/rpc'],
     blockExplorer: 'https://testnet.arbiscan.io/',
     type: 'arbitrum',

--- a/packages/prepo-constants/src/networks.ts
+++ b/packages/prepo-constants/src/networks.ts
@@ -38,7 +38,7 @@ export type SupportedNetworks =
   | 'polygon'
   | 'polygonMumbai'
   | 'smartchain'
-  | 'smartchaintest'
+  | 'smartchainTest'
   | 'arbitrumOne'
   | 'arbitrumTestnet'
 
@@ -186,9 +186,9 @@ export const NETWORKS: Networks = {
     type: 'bsc',
     testNetwork: false,
   },
-  smartchaintest: {
+  smartchainTest: {
     chainName: 'SmartChain Testnet',
-    name: 'smartchaintest',
+    name: 'smartchainTest',
     color: '#F0B90B',
     chainId: ChainId.BSCTestnet,
     rpcUrls: ['https://data-seed-prebsc-1-s1.binance.org:8545'],

--- a/packages/prepo-hardhat/src/generateHardhatConfig.ts
+++ b/packages/prepo-hardhat/src/generateHardhatConfig.ts
@@ -53,7 +53,10 @@ const generateHardhatConfig = (config: HardhatLocalConfig): HardhatUserConfig =>
       kovan: createTestnetConfig(NETWORKS.kovan.name),
       rinkeby: createTestnetConfig(NETWORKS.rinkeby.name),
       ropsten: createTestnetConfig(NETWORKS.ropsten.name),
+      arbitrumOne: createTestnetConfig(NETWORKS.arbitrumOne.name),
+      arbitrumTestnet: createTestnetConfig(NETWORKS.arbitrumTestnet.name),
       polygon: createTestnetConfig(NETWORKS.polygon.name),
+      polygonMumbai: createTestnetConfig(NETWORKS.polygonMumbai.name),
     },
     paths: {
       artifacts: './artifacts',

--- a/packages/prepo-hardhat/src/generateHardhatLocalConfig.ts
+++ b/packages/prepo-hardhat/src/generateHardhatLocalConfig.ts
@@ -2,7 +2,7 @@ export type HardhatLocalConfig = {
   MNEMONIC: string
   INFURA_API_KEY: string
   ETHERSCAN_API_KEY: string
-  OPTIMISTIC_ETHERSCAN_API_KEY: string
+  ARBISCAN_API_KEY: string
   POLYGONSCAN_API_KEY: string
 }
 
@@ -10,6 +10,6 @@ export const generateHardhatLocalConfig = (): HardhatLocalConfig => ({
   MNEMONIC: process.env.MNEMONIC ?? 'test test test test test test test test test test test junk',
   INFURA_API_KEY: process.env.INFURA_API_KEY ?? 'test',
   ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY ?? 'test',
-  OPTIMISTIC_ETHERSCAN_API_KEY: process.env.OPTIMISTIC_ETHERSCAN_API_KEY ?? 'test',
+  ARBISCAN_API_KEY: process.env.ARBISCAN_API_KEY ?? 'test',
   POLYGONSCAN_API_KEY: process.env.POLYGONSCAN_API_KEY ?? 'test',
 })


### PR DESCRIPTION
We need to add support for Arbitrum and Arbitrum One networks to prepare for our token launch. 

I decided to remove specifying `optimisticEthereum` api keys because we don't even have a `Network` definition for Optimism in our shared constants package and are not even using Optimism.

I have renamed our network definition for `mumbai` to `polygonMumbai`, to rationalize the naming with the`@nomiclabs/hardhat-etherscan` library.