### PR TITLE
feat: changed inheritance order of transfer hooks

### DIFF
--- a/apps/smart-contracts/token/contracts/BlocklistTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/BlocklistTransferHook.sol
@@ -23,7 +23,7 @@ contract BlocklistTransferHook is IBlocklistTransferHook, SafeOwnable {
     address _from,
     address _to,
     uint256 _amount
-  ) external override onlyToken {
+  ) public virtual override onlyToken {
     require(!_blocklist.isIncluded(_from), "Sender blocked");
     require(!_blocklist.isIncluded(_to), "Recipient blocked");
   }

--- a/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
@@ -6,12 +6,6 @@ import "./interfaces/IAccountList.sol";
 import "./BlocklistTransferHook.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
-/**
-  TODO: Import BlocklistTransferHook.sol and remove duplicate implementation
-  and tests for setting blocklist.
-  TODO: Call super.hook(...) to check for blocklist in `hook()`.
-*/
-
 contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable, BlocklistTransferHook {
   //TODO: Extract this to a shared contract to reduce duplication.
   address private _token;

--- a/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
@@ -4,16 +4,12 @@ pragma solidity =0.8.7;
 import "./interfaces/IRestrictedTransferHook.sol";
 import "./interfaces/IAccountList.sol";
 import "./BlocklistTransferHook.sol";
-import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
-contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable, BlocklistTransferHook {
-  //TODO: Extract this to a shared contract to reduce duplication.
+contract RestrictedTransferHook is IRestrictedTransferHook, BlocklistTransferHook {
   IAccountList private _sourceAllowlist;
   IAccountList private _destinationAllowlist;
 
-  constructor(address _nominatedOwner) BlocklistTransferHook(_nominatedOwner) {
-    transferOwnership(_nominatedOwner);
-  }
+  constructor(address _nominatedOwner) BlocklistTransferHook(_nominatedOwner) {}
 
   function hook(
     address _from,

--- a/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.7;
 
 import "./interfaces/IRestrictedTransferHook.sol";
 import "./interfaces/IAccountList.sol";
+import "./BlocklistTransferHook.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 /**
@@ -11,19 +12,13 @@ import "prepo-shared-contracts/contracts/SafeOwnable.sol";
   TODO: Call super.hook(...) to check for blocklist in `hook()`.
 */
 
-contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable {
+contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable, BlocklistTransferHook {
   //TODO: Extract this to a shared contract to reduce duplication.
   address private _token;
-  IAccountList private _blocklist;
   IAccountList private _sourceAllowlist;
   IAccountList private _destinationAllowlist;
 
-  modifier onlyToken() {
-    require(msg.sender == _token, "msg.sender != token");
-    _;
-  }
-
-  constructor(address _nominatedOwner) {
+  constructor(address _nominatedOwner) BlocklistTransferHook(_nominatedOwner) {
     transferOwnership(_nominatedOwner);
   }
 
@@ -31,23 +26,14 @@ contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable {
     address _from,
     address _to,
     uint256 _amount
-  ) external override onlyToken {
-    require(!_blocklist.isIncluded(_from), "Sender blocked");
-    require(!_blocklist.isIncluded(_to), "Recipient blocked");
+  ) public virtual override(BlocklistTransferHook, ITransferHook) onlyToken {
+    super.hook(_from, _to, _amount);
     if (_sourceAllowlist.isIncluded(_from)) return;
     require(_destinationAllowlist.isIncluded(_to), "Destination not allowed");
   }
 
-  function setToken(address _newToken) external onlyOwner {
-    _token = _newToken;
-  }
-
-  function setBlocklist(IAccountList _newBlocklist) external override onlyOwner {
-    _blocklist = _newBlocklist;
-  }
-
-  function setSourceAllowlist(IAccountList _newSourceAllowlist) external override onlyOwner {
-    _sourceAllowlist = _newSourceAllowlist;
+  function setSourceAllowlist(IAccountList _newAllowedSources) external override onlyOwner {
+    _sourceAllowlist = _newAllowedSources;
   }
 
   function setDestinationAllowlist(IAccountList _newDestinationAllowlist)
@@ -56,14 +42,6 @@ contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable {
     onlyOwner
   {
     _destinationAllowlist = _newDestinationAllowlist;
-  }
-
-  function getToken() external view returns (address) {
-    return _token;
-  }
-
-  function getBlocklist() external view override returns (IAccountList) {
-    return _blocklist;
   }
 
   function getSourceAllowlist() external view override returns (IAccountList) {

--- a/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
@@ -8,7 +8,6 @@ import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable, BlocklistTransferHook {
   //TODO: Extract this to a shared contract to reduce duplication.
-  address private _token;
   IAccountList private _sourceAllowlist;
   IAccountList private _destinationAllowlist;
 

--- a/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity =0.8.7;
 
 import "./interfaces/IRestrictedTransferHook.sol";

--- a/apps/smart-contracts/token/test/RestrictedTransferHook.test.ts
+++ b/apps/smart-contracts/token/test/RestrictedTransferHook.test.ts
@@ -59,10 +59,6 @@ describe('RestrictedTransferHook', () => {
       expect(await restrictedTransferHook.getToken()).to.eq(ZERO_ADDRESS)
     })
 
-    it('sets blocklist to zero address', async () => {
-      expect(await restrictedTransferHook.getBlocklist()).to.eq(ZERO_ADDRESS)
-    })
-
     it('sets source allowlist to zero address', async () => {
       expect(await restrictedTransferHook.getSourceAllowlist()).to.eq(ZERO_ADDRESS)
     })
@@ -201,50 +197,6 @@ describe('RestrictedTransferHook', () => {
       await restrictedTransferHook.connect(owner).setDestinationAllowlist(JUNK_ADDRESS)
 
       expect(await restrictedTransferHook.getDestinationAllowlist()).to.eq(JUNK_ADDRESS)
-    })
-  })
-
-  describe('# setBlocklist', () => {
-    beforeEach(async () => {
-      await setupHook()
-    })
-
-    it('reverts if not owner', async () => {
-      expect(await restrictedTransferHook.owner()).to.not.eq(user1.address)
-
-      await expect(restrictedTransferHook.connect(user1).setBlocklist(JUNK_ADDRESS)).revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
-
-    it('sets to non-zero address', async () => {
-      expect(await restrictedTransferHook.getBlocklist()).to.not.eq(JUNK_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setBlocklist(JUNK_ADDRESS)
-
-      expect(await restrictedTransferHook.getBlocklist()).to.eq(JUNK_ADDRESS)
-      expect(await restrictedTransferHook.getBlocklist()).to.not.eq(ZERO_ADDRESS)
-    })
-
-    it('sets to zero address', async () => {
-      await restrictedTransferHook.connect(owner).setBlocklist(JUNK_ADDRESS)
-      expect(await restrictedTransferHook.getBlocklist()).to.not.eq(ZERO_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setBlocklist(ZERO_ADDRESS)
-
-      expect(await restrictedTransferHook.getBlocklist()).to.eq(ZERO_ADDRESS)
-    })
-
-    it('is idempotent', async () => {
-      expect(await restrictedTransferHook.getBlocklist()).to.not.eq(JUNK_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setBlocklist(JUNK_ADDRESS)
-
-      expect(await restrictedTransferHook.getBlocklist()).to.eq(JUNK_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setBlocklist(JUNK_ADDRESS)
-
-      expect(await restrictedTransferHook.getBlocklist()).to.eq(JUNK_ADDRESS)
     })
   })
 

--- a/apps/smart-contracts/token/test/RestrictedTransferHook.test.ts
+++ b/apps/smart-contracts/token/test/RestrictedTransferHook.test.ts
@@ -68,50 +68,6 @@ describe('RestrictedTransferHook', () => {
     })
   })
 
-  describe('# setToken', () => {
-    beforeEach(async () => {
-      await setupHook()
-    })
-
-    it('reverts if not owner', async () => {
-      expect(await restrictedTransferHook.owner()).to.not.eq(user1.address)
-
-      await expect(restrictedTransferHook.connect(user1).setToken(JUNK_ADDRESS)).revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
-
-    it('sets to non-zero address', async () => {
-      expect(await restrictedTransferHook.getToken()).to.not.eq(JUNK_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-
-      expect(await restrictedTransferHook.getToken()).to.eq(JUNK_ADDRESS)
-      expect(await restrictedTransferHook.getToken()).to.not.eq(ZERO_ADDRESS)
-    })
-
-    it('sets to zero address', async () => {
-      await restrictedTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-      expect(await restrictedTransferHook.getToken()).to.not.eq(ZERO_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setToken(ZERO_ADDRESS)
-
-      expect(await restrictedTransferHook.getToken()).to.eq(ZERO_ADDRESS)
-    })
-
-    it('is idempotent', async () => {
-      expect(await restrictedTransferHook.getToken()).to.not.eq(JUNK_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-
-      expect(await restrictedTransferHook.getToken()).to.eq(JUNK_ADDRESS)
-
-      await restrictedTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-
-      expect(await restrictedTransferHook.getToken()).to.eq(JUNK_ADDRESS)
-    })
-  })
-
   describe('# setSourceAllowlist', () => {
     beforeEach(async () => {
       await setupHook()
@@ -200,7 +156,7 @@ describe('RestrictedTransferHook', () => {
     })
   })
 
-  describe('hook', () => {
+  describe('# hook', () => {
     let sender: SignerWithAddress
     let recipient: SignerWithAddress
 


### PR DESCRIPTION
* Changed the inheritance, so that `RestrictedTransferHook` can inherit `BlocklistTransferHook` and use its functions internally.
* Since we also need to call `super.hook()`, it meant changing the visibility of `hook` in `BlocklistTransferHook` from `external` to `public` so that it could be called internally.
* Also as we were overriding the `hook`, and it is inherited from both `ITransferHook` and `BlocklistTransferHook` hence had to specify the overriding and at the same time convert the hook function in `BlocklistTransferHook` to virtual so that it can be overridden.
Note:
There was not a strict need to convert the `hook` of `RestrictedTransferHook` to virtual but I have done so to have the flexibility of inheriting and overriding in child contract in case if we want to extend in future.

* Removed set/get Blocklist methods and tests along with setToken method.