### PR TITLE
feat: added generic token setter contract with tests

### DIFF
--- a/packages/prepo-shared-contracts/contracts/Token.sol
+++ b/packages/prepo-shared-contracts/contracts/Token.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+import "./SafeOwnable.sol";
+import "./interfaces/IToken.sol";
+
+contract Token is IToken, SafeOwnable {
+  address private _token;
+
+  modifier onlyToken() {
+    require(msg.sender == _token, "msg.sender != token");
+    _;
+  }
+
+  constructor() {}
+
+  function setToken(address _newToken) external override onlyOwner {
+    _token = _newToken;
+  }
+
+  function getToken() external view override returns (address) {
+    return _token;
+  }
+}

--- a/packages/prepo-shared-contracts/contracts/interfaces/IToken.sol
+++ b/packages/prepo-shared-contracts/contracts/interfaces/IToken.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+// TODO: add natspec comments
+interface IToken {
+  function setToken(address token) external;
+
+  function getToken() external view returns (address);
+}

--- a/packages/prepo-shared-contracts/contracts/mock/TokenWrapper.sol
+++ b/packages/prepo-shared-contracts/contracts/mock/TokenWrapper.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity =0.8.7;
+
+import "../Token.sol";
+
+contract TokenWrapper is Token {
+  function testTokenModifier() external onlyToken {}
+}

--- a/packages/prepo-shared-contracts/test/Token.test.ts
+++ b/packages/prepo-shared-contracts/test/Token.test.ts
@@ -1,0 +1,99 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { ZERO_ADDRESS, JUNK_ADDRESS } from 'prepo-constants'
+import { tokenWrapperFixture } from './fixtures/TokenWrapperFixture'
+import { TokenWrapper } from '../types/generated'
+
+describe('Token', () => {
+  let deployer: SignerWithAddress
+  let owner: SignerWithAddress
+  let user1: SignerWithAddress
+  let user2: SignerWithAddress
+  let token: TokenWrapper
+
+  const setupToken = async (): Promise<void> => {
+    ;[deployer, user1, user2] = await ethers.getSigners()
+    owner = deployer
+    token = await tokenWrapperFixture()
+  }
+
+  describe('initial state', () => {
+    beforeEach(async () => {
+      await setupToken()
+    })
+
+    it('sets owner to deployer', async () => {
+      expect(await token.owner()).to.eq(deployer.address)
+    })
+
+    it('sets nominee to zero address', async () => {
+      expect(await token.getNominee()).to.eq(ZERO_ADDRESS)
+    })
+  })
+
+  describe('# setToken', () => {
+    beforeEach(async () => {
+      await setupToken()
+    })
+
+    it('reverts if not owner', async () => {
+      expect(await token.owner()).to.not.eq(user1.address)
+
+      await expect(token.connect(user1).setToken(JUNK_ADDRESS)).revertedWith(
+        'Ownable: caller is not the owner'
+      )
+    })
+
+    it('sets to non-zero address', async () => {
+      expect(await token.getToken()).to.not.eq(JUNK_ADDRESS)
+
+      await token.connect(owner).setToken(JUNK_ADDRESS)
+
+      expect(await token.getToken()).to.eq(JUNK_ADDRESS)
+      expect(await token.getToken()).to.not.eq(ZERO_ADDRESS)
+    })
+
+    it('sets to zero address', async () => {
+      await token.connect(owner).setToken(JUNK_ADDRESS)
+      expect(await token.getToken()).to.not.eq(ZERO_ADDRESS)
+
+      await token.connect(owner).setToken(ZERO_ADDRESS)
+
+      expect(await token.getToken()).to.eq(ZERO_ADDRESS)
+    })
+
+    it('is idempotent', async () => {
+      expect(await token.getToken()).to.not.eq(JUNK_ADDRESS)
+
+      await token.connect(owner).setToken(JUNK_ADDRESS)
+
+      expect(await token.getToken()).to.eq(JUNK_ADDRESS)
+
+      await token.connect(owner).setToken(JUNK_ADDRESS)
+
+      expect(await token.getToken()).to.eq(JUNK_ADDRESS)
+    })
+  })
+
+  describe('# testTokenModifier', async () => {
+    let genericToken: SignerWithAddress
+    beforeEach(async () => {
+      await setupToken()
+      genericToken = user1
+      await token.connect(owner).setToken(genericToken.address)
+    })
+
+    it('reverts if not token', async () => {
+      expect(await token.getToken()).to.not.eq(user2.address)
+
+      await expect(token.connect(user2).testTokenModifier()).revertedWith('msg.sender != token')
+    })
+
+    it('succeeds if token', async () => {
+      expect(await token.getToken()).to.eq(genericToken.address)
+
+      await expect(token.connect(genericToken).testTokenModifier()).to.not.reverted
+    })
+  })
+})

--- a/packages/prepo-shared-contracts/test/fixtures/TokenWrapperFixture.ts
+++ b/packages/prepo-shared-contracts/test/fixtures/TokenWrapperFixture.ts
@@ -1,0 +1,7 @@
+import { ethers } from 'hardhat'
+import { TokenWrapper } from '../../types/generated'
+
+export async function tokenWrapperFixture(): Promise<TokenWrapper> {
+  const Factory = await ethers.getContractFactory('TokenWrapper')
+  return (await Factory.deploy()) as TokenWrapper
+}


### PR DESCRIPTION
* Adding files for the generic shared token contracts to be used by other contracts for setting tokens and using the inherited modifier `onlyToken`.
* To add a test for the modifier, I had to create a wrapper around `Token.sol`. The wrapper `TokenWrapper.sol` only has one function `testTokenModifier`, which can be called by `onlyToken`.
* The contract `Token.sol` itself inherits from `SafeOwnable` without any constructor arguments, so by default, the `nominee` for `Token.sol` will be `ZERO_ADDRESS`, and the `owner` will be `deployer`.  But when the contract is inherited by any other contract, the `nominee` and `owner` will be of the inheriting contracts.