### PR TITLE
feat: removing duplicate token setters from transfer hook

### DIFF
--- a/apps/smart-contracts/token/contracts/BlocklistTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/BlocklistTransferHook.sol
@@ -4,16 +4,10 @@ pragma solidity =0.8.7;
 import "./interfaces/IBlocklistTransferHook.sol";
 import "./interfaces/IAccountList.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
+import "prepo-shared-contracts/contracts/Token.sol";
 
-contract BlocklistTransferHook is IBlocklistTransferHook, SafeOwnable {
-  //TODO: Extract this to a shared contract to reduce duplication.
-  address private _token;
+contract BlocklistTransferHook is IBlocklistTransferHook, SafeOwnable, Token {
   IAccountList private _blocklist;
-
-  modifier onlyToken() {
-    require(msg.sender == _token, "msg.sender != token");
-    _;
-  }
 
   constructor(address _nominatedOwner) {
     transferOwnership(_nominatedOwner);
@@ -28,16 +22,8 @@ contract BlocklistTransferHook is IBlocklistTransferHook, SafeOwnable {
     require(!_blocklist.isIncluded(_to), "Recipient blocked");
   }
 
-  function setToken(address _newToken) external onlyOwner {
-    _token = _newToken;
-  }
-
   function setBlocklist(IAccountList _newBlocklist) external override onlyOwner {
     _blocklist = _newBlocklist;
-  }
-
-  function getToken() external view returns (address) {
-    return _token;
   }
 
   function getBlocklist() external view override returns (IAccountList) {

--- a/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
+++ b/apps/smart-contracts/token/contracts/RestrictedTransferHook.sol
@@ -7,7 +7,6 @@ import "./BlocklistTransferHook.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
 
 contract RestrictedTransferHook is IRestrictedTransferHook, SafeOwnable, BlocklistTransferHook {
-  //TODO: Extract this to a shared contract to reduce duplication.
   IAccountList private _sourceAllowlist;
   IAccountList private _destinationAllowlist;
 

--- a/apps/smart-contracts/token/test/BlocklistTransferHook.test.ts
+++ b/apps/smart-contracts/token/test/BlocklistTransferHook.test.ts
@@ -56,50 +56,6 @@ describe('BlocklistTransferHook', () => {
     })
   })
 
-  describe('# setToken', () => {
-    beforeEach(async () => {
-      await setupHook()
-    })
-
-    it('reverts if not owner', async () => {
-      expect(await blocklistTransferHook.owner()).to.not.eq(user1.address)
-
-      await expect(blocklistTransferHook.connect(user1).setToken(JUNK_ADDRESS)).revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
-
-    it('sets to non-zero address', async () => {
-      expect(await blocklistTransferHook.getToken()).to.not.eq(JUNK_ADDRESS)
-
-      await blocklistTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-
-      expect(await blocklistTransferHook.getToken()).to.eq(JUNK_ADDRESS)
-      expect(await blocklistTransferHook.getToken()).to.not.eq(ZERO_ADDRESS)
-    })
-
-    it('sets to zero address', async () => {
-      await blocklistTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-      expect(await blocklistTransferHook.getToken()).to.not.eq(ZERO_ADDRESS)
-
-      await blocklistTransferHook.connect(owner).setToken(ZERO_ADDRESS)
-
-      expect(await blocklistTransferHook.getToken()).to.eq(ZERO_ADDRESS)
-    })
-
-    it('is idempotent', async () => {
-      expect(await blocklistTransferHook.getToken()).to.not.eq(JUNK_ADDRESS)
-
-      await blocklistTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-
-      expect(await blocklistTransferHook.getToken()).to.eq(JUNK_ADDRESS)
-
-      await blocklistTransferHook.connect(owner).setToken(JUNK_ADDRESS)
-
-      expect(await blocklistTransferHook.getToken()).to.eq(JUNK_ADDRESS)
-    })
-  })
-
   describe('# setBlocklist', () => {
     beforeEach(async () => {
       await setupHook()


### PR DESCRIPTION
* Switching transfer hook to inherit from the shared `Token` contract.
* Removed duplicated functions and related tests.