### PR TITLE
feat: switching to shared pausable contract

### DIFF
--- a/apps/smart-contracts/token/contracts/TokenShop.sol
+++ b/apps/smart-contracts/token/contracts/TokenShop.sol
@@ -9,24 +9,17 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "./interfaces/ITokenShop.sol";
 import "./interfaces/IPurchaseHook.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
+import "prepo-shared-contracts/contracts/Pausable.sol";
 
-contract TokenShop is ITokenShop, SafeOwnable, ReentrancyGuard {
+contract TokenShop is ITokenShop, SafeOwnable, ReentrancyGuard, Pausable {
   using SafeERC20 for IERC20;
 
   IERC20 private _paymentToken;
-  // TODO: Separate pausing logic to a separate Pausable.sol
-  bool private _paused;
   IPurchaseHook private _purchaseHook;
   mapping(address => mapping(uint256 => uint256)) private _contractToIdToPrice;
   mapping(address => mapping(address => uint256)) private _userToERC721ToPurchaseCount;
   mapping(address => mapping(address => mapping(uint256 => uint256)))
     private _userToERC1155ToIdToPurchaseCount;
-
-  //TODO: move it into Pausable.sol
-  modifier whenNotPaused() {
-    require(!_paused, "Token Shop: paused");
-    _;
-  }
 
   constructor(address _nominatedOwner, address _newPaymentToken) {
     transferOwnership(_nominatedOwner);
@@ -45,10 +38,6 @@ contract TokenShop is ITokenShop, SafeOwnable, ReentrancyGuard {
     for (uint256 i; i < _tokenContracts.length; ++i) {
       _contractToIdToPrice[_tokenContracts[i]][_ids[i]] = _prices[i];
     }
-  }
-
-  function setPaused(bool _newPaused) external override onlyOwner {
-    _paused = _newPaused;
   }
 
   function setPurchaseHook(address _newPurchaseHook) external override onlyOwner {
@@ -116,10 +105,6 @@ contract TokenShop is ITokenShop, SafeOwnable, ReentrancyGuard {
 
   function getPrice(address _tokenContract, uint256 _id) external view override returns (uint256) {
     return _contractToIdToPrice[_tokenContract][_id];
-  }
-
-  function isPaused() external view override returns (bool) {
-    return _paused;
   }
 
   function getPaymentToken() external view override returns (address) {

--- a/apps/smart-contracts/token/contracts/Vesting.sol
+++ b/apps/smart-contracts/token/contracts/Vesting.sol
@@ -5,11 +5,11 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./interfaces/IVesting.sol";
 import "prepo-shared-contracts/contracts/SafeOwnable.sol";
+import "prepo-shared-contracts/contracts/Pausable.sol";
 
-contract Vesting is IVesting, SafeOwnable, ReentrancyGuard {
+contract Vesting is IVesting, SafeOwnable, ReentrancyGuard, Pausable {
   using SafeERC20 for IERC20;
 
-  bool private _paused;
   IERC20 private _token;
   uint256 private _vestingStartTime;
   uint256 private _vestingEndTime;
@@ -21,15 +21,6 @@ contract Vesting is IVesting, SafeOwnable, ReentrancyGuard {
 
   constructor(address _nominatedOwner) {
     transferOwnership(_nominatedOwner);
-  }
-
-  modifier whenNotPaused() {
-    require(!_paused, "paused");
-    _;
-  }
-
-  function setPaused(bool _newPaused) external override onlyOwner {
-    _paused = _newPaused;
   }
 
   function setToken(address _newToken) external override onlyOwner {
@@ -107,10 +98,6 @@ contract Vesting is IVesting, SafeOwnable, ReentrancyGuard {
     if (block.timestamp < _start) return 0;
     uint256 _vested = (_allocated * (block.timestamp - _start)) / (_end - _start);
     return _vested < _allocated ? _vested : _allocated;
-  }
-
-  function getPaused() external view override returns (bool) {
-    return _paused;
   }
 
   function getToken() external view override returns (address) {

--- a/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/ITokenShop.sol
@@ -11,8 +11,6 @@ interface ITokenShop {
     uint256[] memory prices
   ) external;
 
-  function setPaused(bool newPaused) external;
-
   function setPurchaseHook(address newPurchaseHook) external;
 
   //TODO: dev comment that ids can be left as 0 if it's an ERC721
@@ -33,8 +31,6 @@ interface ITokenShop {
   ) external;
 
   function getPrice(address tokenContract, uint256 id) external view returns (uint256);
-
-  function isPaused() external view returns (bool);
 
   function getPaymentToken() external view returns (address);
 

--- a/apps/smart-contracts/token/contracts/interfaces/IVesting.sol
+++ b/apps/smart-contracts/token/contracts/interfaces/IVesting.sol
@@ -18,12 +18,6 @@ interface IVesting {
 
   /**
    * @dev Only callable by `owner()`.
-   * @param newPaused Whether claiming of vested tokens should be paused
-   */
-  function setPaused(bool newPaused) external;
-
-  /**
-   * @dev Only callable by `owner()`.
    * @param newToken Address of the ERC20 token to be vested
    */
   function setToken(address newToken) external;
@@ -57,12 +51,6 @@ interface IVesting {
    * adjusted to be lower.
    */
   function claim() external;
-
-  /**
-   * @return True if claiming of vested tokens is paused,
-   * false otherwise
-   */
-  function getPaused() external view returns (bool);
 
   /**
    * @return Address of the vested tokens

--- a/apps/smart-contracts/token/test/TokenShop.test.ts
+++ b/apps/smart-contracts/token/test/TokenShop.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { FakeContract, MockContract, smock } from '@defi-wonderland/smock'
@@ -8,10 +8,8 @@ import { parseEther } from 'ethers/lib/utils'
 import { ZERO_ADDRESS, JUNK_ADDRESS } from 'prepo-constants'
 import { tokenShopFixture } from './fixtures/TokenShopFixtures'
 import { mockERC20Fixture } from './fixtures/MockERC20Fixtures'
-import { revertReason, ZERO } from '../utils'
+import { ZERO } from '../utils'
 import { TokenShop, MockERC20 } from '../types/generated'
-
-chai.use(smock.matchers)
 
 describe('TokenShop', () => {
   let deployer: SignerWithAddress
@@ -97,7 +95,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).setContractToIdToPrice(tokenContracts, tokenIds, itemPrices)
-      ).revertedWith(revertReason('Ownable: caller is not the owner'))
+      ).revertedWith('Ownable: caller is not the owner')
     })
 
     it('reverts if token contract array length mismatch', async () => {
@@ -110,7 +108,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(owner).setContractToIdToPrice(contractArray, idArray, priceArray)
-      ).revertedWith(revertReason('Array length mismatch'))
+      ).revertedWith('Array length mismatch')
     })
 
     it('reverts if item price array length mismatch', async () => {
@@ -123,7 +121,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(owner).setContractToIdToPrice(contractArray, idArray, priceArray)
-      ).revertedWith(revertReason('Array length mismatch'))
+      ).revertedWith('Array length mismatch')
     })
 
     it('reverts if token id array length mismatch', async () => {
@@ -136,7 +134,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(owner).setContractToIdToPrice(contractArray, idArray, priceArray)
-      ).revertedWith(revertReason('Array length mismatch'))
+      ).revertedWith('Array length mismatch')
     })
 
     it('sets price to non-zero for single item', async () => {
@@ -218,7 +216,7 @@ describe('TokenShop', () => {
       expect(await tokenShop.owner()).to.not.eq(user1.address)
 
       await expect(tokenShop.connect(user1).setPurchaseHook(JUNK_ADDRESS)).revertedWith(
-        revertReason('Ownable: caller is not the owner')
+        'Ownable: caller is not the owner'
       )
     })
 
@@ -274,7 +272,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).purchase(tokenContracts, tokenIds, amounts)
-      ).revertedWith(revertReason('Paused'))
+      ).revertedWith('Paused')
     })
 
     it('reverts if token contract array length mismatch', async () => {
@@ -285,7 +283,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).purchase(mismatchedContractArray, tokenIds, amounts)
-      ).revertedWith(revertReason('Array length mismatch'))
+      ).revertedWith('Array length mismatch')
     })
 
     it('reverts if amount array length mismatch', async () => {
@@ -296,7 +294,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).purchase(tokenContracts, tokenIds, mismatchedAmountArray)
-      ).revertedWith(revertReason('Array length mismatch'))
+      ).revertedWith('Array length mismatch')
     })
 
     it('reverts if token id array length mismatch', async () => {
@@ -307,7 +305,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).purchase(tokenContracts, mismatchedTokenIdArray, amounts)
-      ).revertedWith(revertReason('Array length mismatch'))
+      ).revertedWith('Array length mismatch')
     })
 
     it('reverts if purchase hook is zero address', async () => {
@@ -316,7 +314,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).purchase(tokenContracts, tokenIds, amounts)
-      ).revertedWith(revertReason('Purchase hook not set'))
+      ).revertedWith('Purchase hook not set')
     })
 
     it('reverts if non-purchasable item', async () => {
@@ -327,7 +325,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).purchase([tokenContracts[0]], [erc1155Id1], [erc1155Id1Amount])
-      ).revertedWith(revertReason('Non-purchasable item'))
+      ).revertedWith('Non-purchasable item')
     })
 
     it('reverts if called contract neither ERC1155 nor ERC721', async () => {

--- a/apps/smart-contracts/token/test/TokenShop.test.ts
+++ b/apps/smart-contracts/token/test/TokenShop.test.ts
@@ -209,49 +209,6 @@ describe('TokenShop', () => {
     })
   })
 
-  describe('# setPaused', () => {
-    beforeEach(async () => {
-      await setupTokenShop()
-    })
-
-    it('reverts if not owner', async () => {
-      expect(await tokenShop.owner()).to.not.eq(user1.address)
-
-      await expect(tokenShop.connect(user1).setPaused(true)).revertedWith(
-        revertReason('Ownable: caller is not the owner')
-      )
-    })
-
-    it('pauses', async () => {
-      expect(await tokenShop.isPaused()).to.eq(false)
-
-      await tokenShop.connect(owner).setPaused(true)
-
-      expect(await tokenShop.isPaused()).to.eq(true)
-    })
-
-    it('unpauses', async () => {
-      await tokenShop.connect(owner).setPaused(true)
-      expect(await tokenShop.isPaused()).to.eq(true)
-
-      await tokenShop.connect(owner).setPaused(false)
-
-      expect(await tokenShop.isPaused()).to.eq(false)
-    })
-
-    it('is idempotent', async () => {
-      expect(await tokenShop.isPaused()).to.eq(false)
-
-      await tokenShop.connect(owner).setPaused(true)
-
-      expect(await tokenShop.isPaused()).to.eq(true)
-
-      await tokenShop.connect(owner).setPaused(true)
-
-      expect(await tokenShop.isPaused()).to.eq(true)
-    })
-  })
-
   describe('# setPurchaseHook', () => {
     beforeEach(async () => {
       await setupTokenShop()
@@ -317,7 +274,7 @@ describe('TokenShop', () => {
 
       await expect(
         tokenShop.connect(user1).purchase(tokenContracts, tokenIds, amounts)
-      ).revertedWith(revertReason('Token Shop: paused'))
+      ).revertedWith(revertReason('Paused'))
     })
 
     it('reverts if token contract array length mismatch', async () => {

--- a/apps/smart-contracts/token/test/Vesting.test.ts
+++ b/apps/smart-contracts/token/test/Vesting.test.ts
@@ -72,49 +72,6 @@ describe('Vesting', () => {
     })
   })
 
-  describe('# setPaused', () => {
-    beforeEach(async () => {
-      await setupVesting()
-    })
-
-    it('reverts if not owner', async () => {
-      expect(await vesting.owner()).to.not.eq(user1.address)
-
-      await expect(vesting.connect(user1).setPaused(true)).revertedWith(
-        revertReason('Ownable: caller is not the owner')
-      )
-    })
-
-    it('pauses', async () => {
-      expect(await vesting.connect(owner).getPaused()).to.eq(false)
-
-      await vesting.connect(owner).setPaused(true)
-
-      expect(await vesting.connect(owner).getPaused()).to.eq(true)
-    })
-
-    it('unpauses', async () => {
-      await vesting.connect(owner).setPaused(true)
-      expect(await vesting.connect(owner).getPaused()).to.eq(true)
-
-      await vesting.connect(owner).setPaused(false)
-
-      expect(await vesting.connect(owner).getPaused()).to.eq(false)
-    })
-
-    it('is idempotent', async () => {
-      expect(await vesting.connect(owner).getPaused()).to.eq(false)
-
-      await vesting.connect(owner).setPaused(true)
-
-      expect(await vesting.connect(owner).getPaused()).to.eq(true)
-
-      await vesting.connect(owner).setPaused(true)
-
-      expect(await vesting.connect(owner).getPaused()).to.eq(true)
-    })
-  })
-
   describe('# setToken', () => {
     beforeEach(async () => {
       await setupVesting()
@@ -614,9 +571,9 @@ describe('Vesting', () => {
 
     it('reverts if paused', async () => {
       await vesting.connect(owner).setPaused(true)
-      expect(await vesting.getPaused()).to.be.eq(true)
+      expect(await vesting.isPaused()).to.be.eq(true)
 
-      await expect(vesting.connect(user1).claim()).revertedWith(revertReason('paused'))
+      await expect(vesting.connect(user1).claim()).revertedWith(revertReason('Paused'))
     })
 
     it('reverts if unallocated user', async () => {

--- a/apps/smart-contracts/token/test/Vesting.test.ts
+++ b/apps/smart-contracts/token/test/Vesting.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { BigNumber } from 'ethers'
@@ -10,10 +10,10 @@ import { Web3Provider } from '@ethersproject/providers'
 import { vestingFixture } from './fixtures/VestingFixtures'
 import { mockERC20Fixture } from './fixtures/MockERC20Fixtures'
 import { mockVestingClaimerFixture } from './fixtures/MockVestingClaimerFixtures'
-import { ZERO, ONE, revertReason } from '../utils'
+import { ZERO, ONE } from '../utils'
 import { Vesting, MockERC20, MockVestingClaimer } from '../types/generated'
 
-const { setNextTimestamp, mineBlocks, mineBlock } = utils
+const { mineBlocks, mineBlock } = utils
 
 describe('Vesting', () => {
   let deployer: SignerWithAddress
@@ -81,7 +81,7 @@ describe('Vesting', () => {
       expect(await vesting.owner()).to.not.eq(user1.address)
 
       expect(vesting.connect(user1).setToken(mockERC20Token.address)).revertedWith(
-        revertReason('Ownable: caller is not the owner')
+        'Ownable: caller is not the owner'
       )
     })
 
@@ -130,7 +130,7 @@ describe('Vesting', () => {
       expect(await vesting.owner()).to.not.eq(user1.address)
 
       expect(vesting.connect(user1).setVestingStartTime(vestingStartTime)).revertedWith(
-        revertReason('Ownable: caller is not the owner')
+        'Ownable: caller is not the owner'
       )
     })
 
@@ -139,7 +139,7 @@ describe('Vesting', () => {
       expect(await vesting.getVestingEndTime()).to.be.equals(vestingEndTime)
 
       expect(vesting.connect(owner).setVestingStartTime(invalidVestingStartTime)).revertedWith(
-        revertReason('Vesting start time >= end time')
+        'Vesting start time >= end time'
       )
     })
 
@@ -148,7 +148,7 @@ describe('Vesting', () => {
       expect(await vesting.getVestingEndTime()).to.be.equals(vestingEndTime)
 
       expect(vesting.connect(owner).setVestingStartTime(invalidVestingStartTime)).revertedWith(
-        revertReason('Vesting start time >= end time')
+        'Vesting start time >= end time'
       )
     })
 
@@ -228,7 +228,7 @@ describe('Vesting', () => {
       expect(await vesting.owner()).to.not.eq(user1.address)
 
       expect(vesting.connect(user1).setVestingEndTime(vestingEndTime)).revertedWith(
-        revertReason('Ownable: caller is not the owner')
+        'Ownable: caller is not the owner'
       )
     })
 
@@ -240,7 +240,7 @@ describe('Vesting', () => {
       const invalidVestingEndTime = vestingStartTime - 1
 
       expect(vesting.connect(owner).setVestingEndTime(invalidVestingEndTime)).revertedWith(
-        revertReason('Vesting end time <= start time')
+        'Vesting end time <= start time'
       )
     })
 
@@ -252,7 +252,7 @@ describe('Vesting', () => {
       const invalidVestingEndTime = vestingStartTime
 
       expect(vesting.connect(owner).setVestingEndTime(invalidVestingEndTime)).revertedWith(
-        revertReason('Vesting end time <= start time')
+        'Vesting end time <= start time'
       )
     })
 
@@ -345,7 +345,7 @@ describe('Vesting', () => {
 
       await expect(
         vesting.connect(user1).setAllocations(recipients, amountsAllocated)
-      ).revertedWith(revertReason('Ownable: caller is not the owner'))
+      ).revertedWith('Ownable: caller is not the owner')
     })
 
     it('reverts if array length mismatch', async () => {
@@ -353,7 +353,7 @@ describe('Vesting', () => {
 
       await expect(
         vesting.connect(owner).setAllocations([user1.address], amountsAllocated)
-      ).revertedWith(revertReason('Array length mismatch'))
+      ).revertedWith('Array length mismatch')
     })
 
     it('allocates to single recipient', async () => {
@@ -573,24 +573,20 @@ describe('Vesting', () => {
       await vesting.connect(owner).setPaused(true)
       expect(await vesting.isPaused()).to.be.eq(true)
 
-      await expect(vesting.connect(user1).claim()).revertedWith(revertReason('Paused'))
+      await expect(vesting.connect(user1).claim()).revertedWith('Paused')
     })
 
     it('reverts if unallocated user', async () => {
       expect(await vesting.getAmountAllocated(deployer.address)).to.be.eq(0)
 
-      await expect(vesting.connect(deployer).claim()).revertedWith(
-        revertReason('Claimable amount = 0')
-      )
+      await expect(vesting.connect(deployer).claim()).revertedWith('Claimable amount = 0')
     })
 
     it('reverts if vesting not started', async () => {
       expect(currentTime).to.be.lt(vestingStartTime)
       expect(await vesting.connect(user1).getClaimableAmount(user1.address)).to.be.eq(0)
 
-      await expect(vesting.connect(user1).claim()).revertedWith(
-        revertReason('Claimable amount = 0')
-      )
+      await expect(vesting.connect(user1).claim()).revertedWith('Claimable amount = 0')
     })
 
     it('reverts if allocated amount < already claimed', async () => {
@@ -613,9 +609,7 @@ describe('Vesting', () => {
       await vesting.connect(owner).setAllocations([user1.address], [newAllocation])
       expect(await vesting.getVestedAmount(user1.address)).to.be.lt(claimedAmount)
 
-      await expect(vesting.connect(user1).claim()).revertedWith(
-        revertReason('Claimable amount = 0')
-      )
+      await expect(vesting.connect(user1).claim()).revertedWith('Claimable amount = 0')
     })
 
     it('reverts if allocated amount = already claimed', async () => {
@@ -633,9 +627,7 @@ describe('Vesting', () => {
       await vesting.connect(owner).setAllocations([user1.address], [newAllocation])
       expect(await vesting.getVestedAmount(user1.address)).to.be.lt(claimedAmount)
 
-      await expect(vesting.connect(user1).claim()).revertedWith(
-        revertReason('Claimable amount = 0')
-      )
+      await expect(vesting.connect(user1).claim()).revertedWith('Claimable amount = 0')
     })
 
     it('reverts if vested amount < already claimed', async () => {
@@ -658,9 +650,7 @@ describe('Vesting', () => {
       await vesting.connect(owner).setAllocations([user1.address], [newAllocation])
       expect(await vesting.getVestedAmount(user1.address)).to.be.lt(claimedAmount)
 
-      await expect(vesting.connect(user1).claim()).revertedWith(
-        revertReason('Claimable amount = 0')
-      )
+      await expect(vesting.connect(user1).claim()).revertedWith('Claimable amount = 0')
     })
 
     it('reverts if insufficient balance in contract', async () => {
@@ -672,9 +662,7 @@ describe('Vesting', () => {
       const claimableAmount = await vesting.getClaimableAmount(user1.address)
       await mockERC20Token.connect(owner).transfer(vesting.address, claimableAmount.sub(1))
 
-      await expect(vesting.connect(user1).claim()).revertedWith(
-        revertReason('Insufficient balance in contract')
-      )
+      await expect(vesting.connect(user1).claim()).revertedWith('Insufficient balance in contract')
     })
 
     it('transfers tokens if still vesting', async () => {
@@ -743,9 +731,7 @@ describe('Vesting', () => {
         contractBalanceBefore.sub(expectedChangeInBalance)
       )
 
-      await expect(vesting.connect(user1).claim()).revertedWith(
-        revertReason('Claimable amount = 0')
-      )
+      await expect(vesting.connect(user1).claim()).revertedWith('Claimable amount = 0')
     })
 
     it('transfers multiple times if still vesting', async () => {
@@ -1049,7 +1035,7 @@ describe('Vesting', () => {
 
       expect(
         vesting.connect(user1).withdrawERC20(externalERC20Token.address, amountToWithdraw)
-      ).revertedWith(revertReason('Ownable: caller is not the owner'))
+      ).revertedWith('Ownable: caller is not the owner')
     })
 
     it('reverts if amount > contract balance', async () => {
@@ -1058,7 +1044,7 @@ describe('Vesting', () => {
 
       expect(
         vesting.connect(owner).withdrawERC20(externalERC20Token.address, amountToWithdraw)
-      ).revertedWith(revertReason('ERC20: transfer amount exceeds balance'))
+      ).revertedWith('ERC20: transfer amount exceeds balance')
     })
 
     it('transfers if amount = contract balance', async () => {


### PR DESCRIPTION
* Switching to shared `Pausable.sol` for token contracts.
* Also removed tests for `setPaused()`