### PR TITLE
fix: check icon properties name

### DIFF
--- a/packages/prepo-ui/src/components/Icon/icon-components/application/CheckIcon.tsx
+++ b/packages/prepo-ui/src/components/Icon/icon-components/application/CheckIcon.tsx
@@ -13,9 +13,9 @@ const CheckIcon: React.FC<Props> = ({ width = '24', height = '24' }) => (
     <path
       d="M4 11.8667L8.77273 17L19 6"
       stroke="currentColor"
-      stroke-width="1.40788"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.40788"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 )


### PR DESCRIPTION
Fix this error message

<img width="382" alt="Screenshot 2022-12-13 at 12 05 24 PM" src="https://user-images.githubusercontent.com/81092286/207223961-3e615e5d-ab2a-4620-a8ab-afacef6033fc.png">
